### PR TITLE
해시태그에 배경색 스타일링

### DIFF
--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/Carousel/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/Carousel/index.tsx
@@ -36,8 +36,8 @@ const Carousel = ({ files, carouselWidth }: CarouselProps) => {
       </ChangeImageButton>
       <CarouselWindow>
         <CarouselImage ref={carouselRef} carouselWidth={carouselWidth}>
-          {files.map((fileObject) => (
-            <div>
+          {files.map((fileObject, idx) => (
+            <div key={idx}>
               <img src={URL.createObjectURL(fileObject.file)}></img>
             </div>
           ))}
@@ -48,7 +48,7 @@ const Carousel = ({ files, carouselWidth }: CarouselProps) => {
       </ChangeImageButton>
       <DotContainer>
         {files.map((fileObject, idx) => (
-          <Dot color={imageIndex == idx ? COLOR.BLACK : COLOR.GRAY}></Dot>
+          <Dot key={idx} color={imageIndex == idx ? COLOR.BLACK : COLOR.GRAY}></Dot>
         ))}
       </DotContainer>
     </CarouselContainer>


### PR DESCRIPTION
## 작업 내용
### 게시물 작성 내용란에서 앞에 #을 붙이면 해시태그로 인식하도록 구현

![video1](https://user-images.githubusercontent.com/50266862/140738406-44f9428c-b84b-469a-99c0-55fe2248d889.gif)


## 고민한 부분
[Highlight Text Inside a Textarea](https://codersblock.com/blog/highlight-text-inside-a-textarea/)를 참고해 구현했다.

### 어떻게 div를 겹칠까

```
<ModalRight>
  <div className="backdrop"></div>
  <InputText />
</ModalRight>
```
backdrop 클래스를 갖는 div 태그 아래에 있는 InputText 태그를 `position: relative`를 줬다. relative 값을 주면, 일반적인 흐름에 따라 배치하며, 자신을 기준으로 top, right, bottom, left의 값에 오프셋을 적용할 수 있다.

backdrop의 height를 200px로 고정시킬 것이므로, backdrop에 다음과 같은 코드를 추가했다.
```
const InputText = styled.textarea`
  ...
  position: relative;
  top: -200px;
  ...
`;
```

위 코드로 두 태그(backdrop, InputText)는 같은 크기로 같은 위치에 존재할 수 있게 됐다.

### #을 접두사로 갖는 문자열 찾기
```
const applyHighlights = (textParam: string) => {
  const highlightedText = textParam.replace(/\n$/g, "\n\n").replace(/#([\w|ㄱ-ㅎ|가-힣]+)/g, "<mark>$&</mark>");
  return highlightedText;
};
```

앞의 `replace`는 단일 개행문자로 끝나는 문자열을 개행문자 두 개로 변환하는데, 우리 코드에선 필요 없는 부분인 것 같다. 뒤의 `replace`가 해시태그를 판별하는 부분이다. # 문자 하나와 한글 포함 문자가 1개 이상 존재하면 해당 문자열 바깥을 `mark` 태그로 감싸준다. 스타일을 추가하지 않은 기본 mark 태그는 노란색의 하이라이트를 마킹해준다.

`replace` 첫 번째 파라미터에 정규식을 주면, 두 번째 파라미터에서는 해당 정규식과 매칭되는 그룹을 특수 교체 패턴 문자 중 하나인 `$&` 로 가져다 쓸 수 있다.

### 스크롤이 생겼을 때 sync 맞춰주기

![video2](https://user-images.githubusercontent.com/50266862/140737681-c80bf5b9-bd38-43d3-9dbb-b87f94b4151f.gif)

위 사진처럼 스크롤이 생기는 시점에서는 두 태그 안의 글자의 싱크가 맞지 않게 됐다.

```
const handleScroll = () => {
  const scrollTop = inputRef.current?.scrollTop as number;

  if (!backdropRef.current) return;
  highlightsRef.current.scrollTop = scrollTop;
};
```
`scrollTop` 속성 값을 일치시켜줌으로써, 스크롤이 움직이더라도 **backdrop**과 **InputText**의 글자 위치가 같게끔 맞춰주었다.

## 리뷰 포인트


## 관련된 이슈 넘버
#69 