### PR TITLE
장소 검색 리스트 출력, 무한 스크롤 구현

### DIFF
--- a/frontend/public/icons/arrow-left.svg
+++ b/frontend/public/icons/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 20L8 12L16 4" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -27,6 +27,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=90d6cfc5fa42851cba76ef070e3ff208&libraries=services"></script>
     <div id="modal"></div>
     <!--
       This HTML file is a template.

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -5,6 +5,12 @@ import { flexRowCenterAlign } from "@styles/StyledComponents";
 import { useDispatch } from "react-redux";
 import Marker from "@components/Map/Markers";
 
+declare global {
+  interface Window {
+    kakao: any;
+  }
+}
+
 const load = (url: string, cb: Function, err: Function) => {
   const element = document.createElement("script");
   const parent = "body";

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/ModalSub.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/ModalSub.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import COLOR from "@src/styles/Color";
-import React, { useState, useEffect, useRef, Dispatch, SetStateAction } from "react";
+import React, { useState, useEffect, Dispatch, SetStateAction } from "react";
 import { flexRowCenterAlign } from "@src/styles/StyledComponents";
 import SearchResult from "@components/Modal/PostCreateModal/UploadInfoModal/SearchResult";
 
@@ -10,11 +10,6 @@ interface IData {
 
 interface IPagination {
   [key: string]: string;
-}
-
-interface ISearchResult {
-  data: IData[];
-  pagination: IPagination;
 }
 
 interface ModalSubProps {
@@ -42,7 +37,6 @@ const ModalSub = ({
   lastPage,
   setLastPage,
 }: ModalSubProps) => {
-  const searchInputRef = useRef<HTMLInputElement>(null);
   const [input, setInput] = useState<string>("");
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -93,15 +87,13 @@ const ModalSub = ({
   }, []);
 
   useEffect(() => {
-    if (!searchInputRef.current || !searchInputRef.current.value) return;
-    const keyword = searchInputRef.current.value as string;
-    execSearch(keyword, 1);
+    if (input === "") return;
+    execSearch(input, 1);
   }, [searchKeyword]);
 
   useEffect(() => {
-    if (!searchInputRef.current || !searchInputRef.current.value) return;
-    const keyword = searchInputRef.current.value as string;
-    execSearch(keyword, page);
+    if (input === "") return;
+    execSearch(input, page);
   }, [page]);
 
   return (
@@ -110,7 +102,6 @@ const ModalSub = ({
         <SearchContainer>
           <img src="/icons/search.svg" height="90%" alt="search" />
           <SearchInput
-            ref={searchInputRef}
             type="text"
             placeholder="지역명을 입력하세요."
             onKeyDown={handleKeyPress}

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/ModalSub.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/ModalSub.tsx
@@ -1,0 +1,157 @@
+import styled from "styled-components";
+import COLOR from "@src/styles/Color";
+import React, { useState, useEffect, useRef, Dispatch, SetStateAction } from "react";
+import { flexRowCenterAlign } from "@src/styles/StyledComponents";
+import SearchResult from "@components/Modal/PostCreateModal/UploadInfoModal/SearchResult";
+
+interface IData {
+  [key: string]: string;
+}
+
+interface IPagination {
+  [key: string]: string;
+}
+
+interface ISearchResult {
+  data: IData[];
+  pagination: IPagination;
+}
+
+interface ModalSubProps {
+  setIsSubOpened: Dispatch<SetStateAction<boolean>>;
+  setSelectedLocation: Dispatch<SetStateAction<IData>>;
+}
+
+const ModalSub = ({ setIsSubOpened, setSelectedLocation }: ModalSubProps) => {
+  const [searchKeyword, setSearchKeyword] = useState<string>("");
+  const [page, setPage] = useState<number>(1);
+  const [searchResult, setSearchResult] = useState<IData[]>([]);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const handleKeyPress = async (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "Enter") return;
+
+    const el = e.target as HTMLInputElement;
+    const keyword = el.value;
+    setSearchKeyword(keyword);
+  };
+
+  const onClickCloseBtn = () => {
+    setIsSubOpened(false);
+  };
+
+  const execSearch = (keyword: string, nowPage: number) => {
+    const ps = new window.kakao.maps.services.Places();
+    const placesSearchCB = (data: IData[], status: number, pagination: IPagination) => {
+      if (status === window.kakao.maps.services.Status.ZERO_RESULT) {
+        alert("검색 결과가 존재하지 않습니다.");
+        return;
+      }
+
+      if (status === window.kakao.maps.services.Status.ERROR) {
+        alert("검색 결과 중 오류가 발생했습니다.");
+        return;
+      }
+
+      if (nowPage === 1) {
+        setSearchResult([...data]);
+        setPage(1);
+        return;
+      }
+
+      setSearchResult([...searchResult, ...data]);
+    };
+
+    ps.keywordSearch(keyword, placesSearchCB, { page: nowPage });
+  };
+
+  useEffect(() => {
+    if (!searchInputRef.current || !searchInputRef.current.value) return;
+    const keyword = searchInputRef.current.value as string;
+    execSearch(keyword, 1);
+  }, [searchKeyword]);
+
+  useEffect(() => {
+    if (!searchInputRef.current || !searchInputRef.current.value) return;
+    const keyword = searchInputRef.current.value as string;
+    execSearch(keyword, page);
+  }, [page]);
+
+  return (
+    <ModalSubWrapper>
+      <ModalHeader className="header-sub">
+        <SearchContainer>
+          <img src="/icons/search.svg" height="90%" alt="search" />
+          <SearchInput
+            ref={searchInputRef}
+            type="text"
+            placeholder="지역명을 입력하세요."
+            onKeyPress={handleKeyPress}
+          />
+        </SearchContainer>
+      </ModalHeader>
+      {!!searchResult.length && (
+        <SearchResult
+          searchResult={searchResult}
+          setSelectedLocation={setSelectedLocation}
+          page={page}
+          setPage={setPage}
+        />
+      )}
+      <CloseBtn onClick={onClickCloseBtn}>
+        <img src="/icons/arrow-left.svg" alt="arrow left icon" />
+      </CloseBtn>
+    </ModalSubWrapper>
+  );
+};
+
+const ModalSubWrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid ${COLOR.BLACK};
+  z-index: 3;
+  width: 300px;
+`;
+const ModalHeader = styled.div`
+  display: grid;
+  grid-template-columns: 10% 80% 10%;
+  padding: 1vw;
+  height: 60px;
+  box-sizing: border-box;
+  border-bottom: 1px solid ${COLOR.BLACK};
+  font-size: max(1.2vw, 20px);
+`;
+const SearchContainer = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  height: 3vh;
+  width: 100%;
+  background-color: ${COLOR.WHITE};
+  border-radius: 5px;
+  padding: 0.5vh 0;
+  & > img {
+    padding: 0 0.5vw;
+  }
+`;
+const SearchInput = styled.input`
+  height: 90%;
+  border: none;
+  &:focus-visible {
+    outline: none;
+  }
+`;
+const CloseBtn = styled.div`
+  ${flexRowCenterAlign}
+  position: absolute;
+  left: 85%;
+  width: 3rem;
+  height: 3.71rem;
+  background-color: ${COLOR.WHITE};
+  border-radius: 1rem;
+  cursor: pointer;
+  z-index: 1;
+`;
+
+export default ModalSub;

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/ModalSub.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/ModalSub.tsx
@@ -18,17 +18,34 @@ interface ISearchResult {
 }
 
 interface ModalSubProps {
+  searchKeyword: string;
+  setSearchKeyword: Dispatch<SetStateAction<string>>;
   setIsSubOpened: Dispatch<SetStateAction<boolean>>;
   setSelectedLocation: Dispatch<SetStateAction<IData>>;
+  searchResult: IData[];
+  setSearchResult: Dispatch<SetStateAction<IData[]>>;
+  page: number;
+  setPage: Dispatch<SetStateAction<number>>;
+  lastPage: number;
+  setLastPage: Dispatch<SetStateAction<number>>;
 }
 
-const ModalSub = ({ setIsSubOpened, setSelectedLocation }: ModalSubProps) => {
-  const [searchKeyword, setSearchKeyword] = useState<string>("");
-  const [page, setPage] = useState<number>(1);
-  const [searchResult, setSearchResult] = useState<IData[]>([]);
+const ModalSub = ({
+  searchKeyword,
+  setSearchKeyword,
+  setIsSubOpened,
+  setSelectedLocation,
+  searchResult,
+  setSearchResult,
+  page,
+  setPage,
+  lastPage,
+  setLastPage,
+}: ModalSubProps) => {
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const [input, setInput] = useState<string>("");
 
-  const handleKeyPress = async (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key !== "Enter") return;
 
     const el = e.target as HTMLInputElement;
@@ -36,8 +53,13 @@ const ModalSub = ({ setIsSubOpened, setSelectedLocation }: ModalSubProps) => {
     setSearchKeyword(keyword);
   };
 
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInput(e.target.value);
+  };
+
   const onClickCloseBtn = () => {
     setIsSubOpened(false);
+    setSearchKeyword(input);
   };
 
   const execSearch = (keyword: string, nowPage: number) => {
@@ -56,6 +78,7 @@ const ModalSub = ({ setIsSubOpened, setSelectedLocation }: ModalSubProps) => {
       if (nowPage === 1) {
         setSearchResult([...data]);
         setPage(1);
+        setLastPage(Number(pagination.last));
         return;
       }
 
@@ -64,6 +87,10 @@ const ModalSub = ({ setIsSubOpened, setSelectedLocation }: ModalSubProps) => {
 
     ps.keywordSearch(keyword, placesSearchCB, { page: nowPage });
   };
+
+  useEffect(() => {
+    setInput(searchKeyword);
+  }, []);
 
   useEffect(() => {
     if (!searchInputRef.current || !searchInputRef.current.value) return;
@@ -86,7 +113,9 @@ const ModalSub = ({ setIsSubOpened, setSelectedLocation }: ModalSubProps) => {
             ref={searchInputRef}
             type="text"
             placeholder="지역명을 입력하세요."
-            onKeyPress={handleKeyPress}
+            onKeyDown={handleKeyPress}
+            value={input}
+            onChange={handleInputChange}
           />
         </SearchContainer>
       </ModalHeader>
@@ -96,6 +125,7 @@ const ModalSub = ({ setIsSubOpened, setSelectedLocation }: ModalSubProps) => {
           setSelectedLocation={setSelectedLocation}
           page={page}
           setPage={setPage}
+          lastPage={lastPage}
         />
       )}
       <CloseBtn onClick={onClickCloseBtn}>

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/SearchResult/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/SearchResult/index.tsx
@@ -22,7 +22,9 @@ const SearchResult = ({ searchResult, setSelectedLocation }: SearchResultProps) 
           <PlaceName>{location.place_name}</PlaceName>
           <RoadAddressName>{location.road_address_name}</RoadAddressName>
           <AddressName>
-            <img src="https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/places_jibun.png" />
+            <span>
+              <img src="https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/places_jibun.png" />
+            </span>
             {location.address_name}
           </AddressName>
         </PlaceWrapper>
@@ -34,12 +36,15 @@ const SearchResultWrapper = styled.div`
   display: flex;
   flex-direction: column;
   overflow-y: scroll;
+  height: 100%;
+  box-sizing: border-box;
 `;
 
 const PlaceWrapper = styled.div`
   cursor: pointer;
   border-bottom: 1px solid ${COLOR.BLACK};
   padding: 0.5rem;
+  box-sizing: border-box;
 
   &:hover {
     background: ${COLOR.GRAY};

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/SearchResult/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/SearchResult/index.tsx
@@ -11,9 +11,10 @@ interface SearchResultProps {
   setSelectedLocation: Dispatch<SetStateAction<IData>>;
   page: number;
   setPage: Dispatch<SetStateAction<number>>;
+  lastPage: number;
 }
 
-const SearchResult = ({ searchResult, setSelectedLocation, page, setPage }: SearchResultProps) => {
+const SearchResult = ({ searchResult, setSelectedLocation, page, setPage, lastPage }: SearchResultProps) => {
   const data = searchResult;
   const searchResultWrapperRef = useRef() as React.MutableRefObject<HTMLDivElement>;
 
@@ -26,7 +27,7 @@ const SearchResult = ({ searchResult, setSelectedLocation, page, setPage }: Sear
     const isBottom = target.scrollHeight - target.scrollTop === target.clientHeight;
 
     if (!isBottom) return;
-    if (page === 3) return;
+    if (page === lastPage) return;
 
     setPage((prev) => prev + 1);
   };
@@ -52,6 +53,7 @@ const SearchResult = ({ searchResult, setSelectedLocation, page, setPage }: Sear
     </SearchResultWrapper>
   );
 };
+
 const SearchResultWrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -59,7 +61,6 @@ const SearchResultWrapper = styled.div`
   height: 100%;
   box-sizing: border-box;
 `;
-
 const PlaceWrapper = styled.div`
   cursor: pointer;
   border-bottom: 1px solid ${COLOR.BLACK};
@@ -70,18 +71,15 @@ const PlaceWrapper = styled.div`
     background: ${COLOR.GRAY};
   }
 `;
-
 const PlaceName = styled.div`
   font-size: 1rem;
   font-weight: bold;
   margin-top: 0.3rem;
 `;
-
 const RoadAddressName = styled.div`
   font-size: 0.8rem;
   margin-top: 0.3rem;
 `;
-
 const AddressName = styled.div`
   display: flex;
   color: ${COLOR.DARKGRAY};
@@ -89,6 +87,4 @@ const AddressName = styled.div`
   margin: 0.3rem 0;
 `;
 
-const Pagination = styled.div``;
-const Page = styled.span``;
 export default SearchResult;

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/SearchResult/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/SearchResult/index.tsx
@@ -1,0 +1,58 @@
+import styled from "styled-components";
+import COLOR from "@styles/Color";
+
+interface IData {
+  [key: string]: string;
+}
+
+const SearchResult = ({ searchResult }: any) => {
+  return (
+    <SearchResultWrapper>
+      {searchResult.map((location: IData) => (
+        <PlaceWrapper>
+          <PlaceName>{location.place_name}</PlaceName>
+          <RoadAddressName>{location.road_address_name}</RoadAddressName>
+          <AddressName>
+            <img src="https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/places_jibun.png" />
+            {location.address_name}
+          </AddressName>
+        </PlaceWrapper>
+      ))}
+    </SearchResultWrapper>
+  );
+};
+const SearchResultWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  overflow-y: scroll;
+`;
+
+const PlaceWrapper = styled.div`
+  cursor: pointer;
+  border-bottom: 1px solid ${COLOR.BLACK};
+  padding: 0.5rem;
+
+  &:hover {
+    background: ${COLOR.GRAY};
+  }
+`;
+
+const PlaceName = styled.div`
+  font-size: 1rem;
+  font-weight: bold;
+  margin-top: 0.3rem;
+`;
+
+const RoadAddressName = styled.div`
+  font-size: 0.8rem;
+  margin-top: 0.3rem;
+`;
+
+const AddressName = styled.div`
+  display: flex;
+  color: ${COLOR.DARKGRAY};
+  font-size: 0.8rem;
+  margin: 0.3rem 0;
+`;
+
+export default SearchResult;

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/SearchResult/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/SearchResult/index.tsx
@@ -1,15 +1,24 @@
 import styled from "styled-components";
 import COLOR from "@styles/Color";
+import { Dispatch, SetStateAction } from "react";
 
 interface IData {
   [key: string]: string;
 }
+interface SearchResultProps {
+  searchResult: IData[];
+  setSelectedLocation: Dispatch<SetStateAction<IData>>;
+}
 
-const SearchResult = ({ searchResult }: any) => {
+const SearchResult = ({ searchResult, setSelectedLocation }: SearchResultProps) => {
+  const handleClickPlaceWrapper = (location: IData) => {
+    setSelectedLocation(location);
+  };
+
   return (
     <SearchResultWrapper>
-      {searchResult.map((location: IData) => (
-        <PlaceWrapper>
+      {searchResult.map((location: IData, idx) => (
+        <PlaceWrapper key={idx} onClick={() => handleClickPlaceWrapper(location)}>
           <PlaceName>{location.place_name}</PlaceName>
           <RoadAddressName>{location.road_address_name}</RoadAddressName>
           <AddressName>

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/SearchResult/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/SearchResult/index.tsx
@@ -1,23 +1,43 @@
 import styled from "styled-components";
 import COLOR from "@styles/Color";
-import { Dispatch, SetStateAction } from "react";
+import React, { Dispatch, SetStateAction, UIEvent, useEffect, useRef } from "react";
 
 interface IData {
   [key: string]: string;
 }
+
 interface SearchResultProps {
   searchResult: IData[];
   setSelectedLocation: Dispatch<SetStateAction<IData>>;
+  page: number;
+  setPage: Dispatch<SetStateAction<number>>;
 }
 
-const SearchResult = ({ searchResult, setSelectedLocation }: SearchResultProps) => {
+const SearchResult = ({ searchResult, setSelectedLocation, page, setPage }: SearchResultProps) => {
+  const data = searchResult;
+  const searchResultWrapperRef = useRef() as React.MutableRefObject<HTMLDivElement>;
+
   const handleClickPlaceWrapper = (location: IData) => {
     setSelectedLocation(location);
   };
 
+  const handleScroll = (e: UIEvent<HTMLElement>) => {
+    const target = e.target as HTMLDivElement;
+    const isBottom = target.scrollHeight - target.scrollTop === target.clientHeight;
+
+    if (!isBottom) return;
+    if (page === 3) return;
+
+    setPage((prev) => prev + 1);
+  };
+
+  useEffect(() => {
+    if (page === 1) searchResultWrapperRef.current.scrollTop = 0;
+  });
+
   return (
-    <SearchResultWrapper>
-      {searchResult.map((location: IData, idx) => (
+    <SearchResultWrapper ref={searchResultWrapperRef} onScroll={handleScroll}>
+      {data.map((location: IData, idx) => (
         <PlaceWrapper key={idx} onClick={() => handleClickPlaceWrapper(location)}>
           <PlaceName>{location.place_name}</PlaceName>
           <RoadAddressName>{location.road_address_name}</RoadAddressName>
@@ -69,4 +89,6 @@ const AddressName = styled.div`
   margin: 0.3rem 0;
 `;
 
+const Pagination = styled.div``;
+const Page = styled.span``;
 export default SearchResult;

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
@@ -5,6 +5,7 @@ import COLOR from "@styles/Color";
 import { useDispatch } from "react-redux";
 import Carousel from "@components/Modal/PostCreateModal/UploadInfoModal/Carousel";
 import SearchResult from "@components/Modal/PostCreateModal/UploadInfoModal/SearchResult";
+import { flexRowCenterAlign } from "@src/styles/StyledComponents";
 
 interface FileObject {
   file: File;
@@ -72,6 +73,7 @@ const UploadInfoModal = ({ changeMode, files }: UploadInfoModalProps) => {
   const handleSearchInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchKeyword(e.target.value);
   };
+
   const handleKeyPress = async (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key !== "Enter") return;
 
@@ -93,6 +95,10 @@ const UploadInfoModal = ({ changeMode, files }: UploadInfoModalProps) => {
     };
 
     ps.keywordSearch(keyword, placesSearchCB);
+  };
+
+  const onClickCloseBtn = () => {
+    setIsSubOpened(false);
   };
 
   useEffect(() => {
@@ -151,7 +157,7 @@ const UploadInfoModal = ({ changeMode, files }: UploadInfoModalProps) => {
 
       {isSubOpened && (
         <ModalSub>
-          <ModalHeader>
+          <ModalHeader className="header-sub">
             <SearchContainer>
               <img src="/icons/search.svg" height="90%" alt="search" />
               <SearchInput
@@ -166,6 +172,9 @@ const UploadInfoModal = ({ changeMode, files }: UploadInfoModalProps) => {
           {!!searchResult.length && (
             <SearchResult searchResult={searchResult} setSelectedLocation={setSelectedLocation} />
           )}
+          <CloseBtn onClick={onClickCloseBtn}>
+            <img src="/icons/arrow-left.svg" alt="arrow left icon" />
+          </CloseBtn>
         </ModalSub>
       )}
     </ModalContainer>
@@ -304,19 +313,16 @@ const ModalRight = styled.div`
     }
   }
 `;
-
 const ModalLeft = styled.div`
   width: 100%;
   height: 45vh;
 `;
-
 const ModalContent = styled.div`
   display: grid;
   height: 100%;
   grid-template-columns: 50% 50%;
   box-sizing: border-box;
 `;
-
 const ModalContainer = styled.div<{ isSubOpened: boolean }>`
   display: flex;
   flex-direction: row;
@@ -326,20 +332,19 @@ const ModalContainer = styled.div<{ isSubOpened: boolean }>`
   border-radius: 10px;
   box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
 `;
-
 const ModalMain = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
 `;
 const ModalSub = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   border-left: 1px solid ${COLOR.BLACK};
   z-index: 3;
   width: 300px;
 `;
-
 const ModalHeaderLeftBtn = styled.button`
   grid-column-start: 1;
   grid-column-end: 2;
@@ -349,7 +354,6 @@ const ModalHeaderLeftBtn = styled.button`
   background: none;
   cursor: pointer;
 `;
-
 const ModalHeaderRigthBtn = styled.button`
   grid-column-start: 3;
   grid-column-end: 4;
@@ -359,7 +363,6 @@ const ModalHeaderRigthBtn = styled.button`
   background: none;
   cursor: pointer;
 `;
-
 const ModalHeader = styled.div`
   display: grid;
   grid-template-columns: 10% 80% 10%;
@@ -369,7 +372,6 @@ const ModalHeader = styled.div`
   border-bottom: 1px solid ${COLOR.BLACK};
   font-size: max(1.2vw, 20px);
 `;
-
 const ModalTitle = styled.div`
   grid-column-start: 2;
   grid-column-end: 3;
@@ -380,7 +382,6 @@ const ModalTitle = styled.div`
   justify-content: center;
   align-items: center;
 `;
-
 const SearchContainer = styled.div`
   display: flex;
   justify-content: flex-start;
@@ -394,11 +395,22 @@ const SearchContainer = styled.div`
     padding: 0 0.5vw;
   }
 `;
-
 const SearchInput = styled.input`
   height: 90%;
   border: none;
   &:focus-visible {
     outline: none;
   }
+`;
+
+const CloseBtn = styled.div`
+  ${flexRowCenterAlign}
+  position: absolute;
+  left: 85%;
+  width: 3rem;
+  height: 3.71rem;
+  background-color: ${COLOR.WHITE};
+  border-radius: 1rem;
+  cursor: pointer;
+  z-index: 1;
 `;

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import COLOR from "@styles/Color";
 import { useDispatch } from "react-redux";
 import Carousel from "@components/Modal/PostCreateModal/UploadInfoModal/Carousel";
+import SearchResult from "@components/Modal/PostCreateModal/UploadInfoModal/SearchResult";
 
 interface FileObject {
   file: File;
@@ -21,20 +22,6 @@ interface IData {
 interface IPagination {
   [key: string]: string;
 }
-
-const SearchResult = ({ searchResult }: any) => {
-  console.log("in SearchResult, searchResult : ", searchResult);
-  return (
-    <SearchResultWrapper>
-      {searchResult.map((location: IData) => (
-        <PlaceWrapper>
-          <PlaceName>{location.place_name}</PlaceName>
-          <AddressName>{location.address_name}</AddressName>
-        </PlaceWrapper>
-      ))}
-    </SearchResultWrapper>
-  );
-};
 
 const UploadInfoModal = ({ changeMode, files }: UploadInfoModalProps) => {
   const [title, setTitle] = useState<string>("");
@@ -100,14 +87,6 @@ const UploadInfoModal = ({ changeMode, files }: UploadInfoModalProps) => {
         alert("검색 결과 중 오류가 발생했습니다.");
         return;
       }
-
-      console.log(`data : ${data}, status : ${status}, pagination : ${pagination}`);
-
-      for (const location of data) {
-        console.log("location : ", location);
-      }
-      console.log("data.length : ", data.length);
-      console.log(pagination);
 
       setSearchResult(data);
     };
@@ -416,27 +395,4 @@ const SearchInput = styled.input`
   &:focus-visible {
     outline: none;
   }
-`;
-
-const SearchResultWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  overflow-y: scroll;
-`;
-
-const PlaceWrapper = styled.div`
-  cursor: pointer;
-  border-bottom: 1px solid ${COLOR.BLACK};
-  &:hover {
-    background: ${COLOR.GRAY};
-  }
-`;
-
-const PlaceName = styled.div`
-  font-size: 1rem;
-  font-weight: bold;
-`;
-
-const AddressName = styled.div`
-  font-size: 0.8rem;
 `;

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState, useRef, ChangeEvent } from "react";
 import styled from "styled-components";
 import COLOR from "@styles/Color";
 import { useDispatch } from "react-redux";
@@ -17,6 +17,8 @@ const UploadInfoModal = ({ changeMode, files }: UploadInfoModalProps) => {
   const [title, setTitle] = useState<string>("");
   const [text, setText] = useState<string>("");
   const [activate, setActivate] = useState<boolean>(false);
+  const [isSubOpened, setIsSubOpened] = useState(false);
+  const [searchKeyword, setSearchKeyword] = useState<string>("");
   const dispatch = useDispatch();
   const highlightsRef = useRef() as React.MutableRefObject<HTMLDivElement>;
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -51,6 +53,15 @@ const UploadInfoModal = ({ changeMode, files }: UploadInfoModalProps) => {
     highlightsRef.current.scrollTop = scrollTop;
   };
 
+  const onClickLocationBtn = () => {
+    setIsSubOpened((prev) => !prev);
+  };
+
+  const handleSearchInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setSearchKeyword(e.target.value);
+  };
+  const handleKeyPress = () => {};
+
   useEffect(() => {
     if (title.length == 0) setActivate(false);
     else setActivate(true);
@@ -61,44 +72,64 @@ const UploadInfoModal = ({ changeMode, files }: UploadInfoModalProps) => {
       onClick={(event) => {
         event.nativeEvent.stopImmediatePropagation();
       }}
+      isSubOpened={isSubOpened}
     >
-      <ModalHeader>
-        <ModalTitle>새 게시물 만들기</ModalTitle>
-        <ModalHeaderRigthBtn onClick={closeModal}>
-          <img src="/icons/x.svg" alt="close" height="90%"></img>
-        </ModalHeaderRigthBtn>
-        <ModalHeaderLeftBtn onClick={changeMode}>
-          <img src="/icons/prev.svg" alt="prev modal" height="90%"></img>
-        </ModalHeaderLeftBtn>
-      </ModalHeader>
-      <ModalContent>
-        <ModalLeft>
-          <Carousel files={files} carouselWidth={250} />
-        </ModalLeft>
-        <ModalRight>
-          <InputTitle type="text" placeholder="제목" value={title} onChange={handelTitleInput} />
-          <div className="backdrop" ref={backdropRef}>
-            <div ref={highlightsRef} className="highlights"></div>
-          </div>
-          <InputText
-            ref={inputRef}
-            placeholder="내용"
-            value={text}
-            onChange={handelTextInput}
-            onScroll={handleScroll}
-          />
-          <InputBottom>
-            <InputDate type="date" />
-            <InputPlace>
-              <InputPlaceName>장소이름</InputPlaceName>
-              <LocationButton>
-                <img src="/icons/location.svg" width="100%" />
-              </LocationButton>
-            </InputPlace>
-          </InputBottom>
-          <UploadButton activate={activate}>게시하기</UploadButton>
-        </ModalRight>
-      </ModalContent>
+      <ModalMain>
+        <ModalHeader>
+          <ModalTitle>새 게시물 만들기</ModalTitle>
+          <ModalHeaderRigthBtn onClick={closeModal}>
+            <img src="/icons/x.svg" alt="close" height="90%"></img>
+          </ModalHeaderRigthBtn>
+          <ModalHeaderLeftBtn onClick={changeMode}>
+            <img src="/icons/prev.svg" alt="prev modal" height="90%"></img>
+          </ModalHeaderLeftBtn>
+        </ModalHeader>
+        <ModalContent>
+          <ModalLeft>
+            <Carousel files={files} carouselWidth={250} />
+          </ModalLeft>
+          <ModalRight>
+            <InputTitle type="text" placeholder="제목" value={title} onChange={handelTitleInput} />
+            <div className="backdrop" ref={backdropRef}>
+              <div ref={highlightsRef} className="highlights"></div>
+            </div>
+            <InputText
+              ref={inputRef}
+              placeholder="내용"
+              value={text}
+              onChange={handelTextInput}
+              onScroll={handleScroll}
+            />
+            <InputBottom>
+              <InputDate type="date" />
+              <InputPlace>
+                <InputPlaceName>장소이름</InputPlaceName>
+                <LocationButton onClick={onClickLocationBtn}>
+                  <img src="/icons/location.svg" width="100%" />
+                </LocationButton>
+              </InputPlace>
+            </InputBottom>
+            <UploadButton activate={activate}>게시하기</UploadButton>
+          </ModalRight>
+        </ModalContent>
+      </ModalMain>
+
+      {isSubOpened && (
+        <ModalSub>
+          <ModalHeader>
+            <SearchContainer>
+              <img src="/icons/search.svg" height="90%" alt="search" />
+              <SearchInput
+                type="text"
+                placeholder="지역명을 입력하세요."
+                onKeyPress={handleKeyPress}
+                onChange={handleSearchInputChange}
+                value={searchKeyword}
+              />
+            </SearchContainer>
+          </ModalHeader>
+        </ModalSub>
+      )}
     </ModalContainer>
   );
 };
@@ -247,14 +278,27 @@ const ModalContent = styled.div`
   box-sizing: border-box;
 `;
 
-const ModalContainer = styled.div`
+const ModalContainer = styled.div<{ isSubOpened: boolean }>`
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   background-color: ${COLOR.WHITE};
-  width: 850px;
+  width: ${(props) => (props.isSubOpened ? "1000px" : "850px")};
   height: 530px;
   border-radius: 10px;
   box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
+`;
+
+const ModalMain = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+const ModalSub = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid ${COLOR.BLACK};
+  z-index: 3;
+  width: 300px;
 `;
 
 const ModalHeaderLeftBtn = styled.button`
@@ -296,4 +340,26 @@ const ModalTitle = styled.div`
   flex-direction: row;
   justify-content: center;
   align-items: center;
+`;
+
+const SearchContainer = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  height: 3vh;
+  width: 100%;
+  background-color: ${COLOR.WHITE};
+  border-radius: 5px;
+  padding: 0.5vh 0;
+  & > img {
+    padding: 0 0.5vw;
+  }
+`;
+
+const SearchInput = styled.input`
+  height: 90%;
+  border: none;
+  &:focus-visible {
+    outline: none;
+  }
 `;

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
@@ -30,6 +30,7 @@ const UploadInfoModal = ({ changeMode, files }: UploadInfoModalProps) => {
   const [isSubOpened, setIsSubOpened] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState<string>("");
   const [searchResult, setSearchResult] = useState<Array<IData>>([]);
+  const [selectedLocation, setSelectedLocation] = useState<IData>({});
   const dispatch = useDispatch();
   const highlightsRef = useRef() as React.MutableRefObject<HTMLDivElement>;
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -135,7 +136,9 @@ const UploadInfoModal = ({ changeMode, files }: UploadInfoModalProps) => {
             <InputBottom>
               <InputDate type="date" />
               <InputPlace>
-                <InputPlaceName>장소이름</InputPlaceName>
+                <InputPlaceName>
+                  {Object.keys(selectedLocation).length === 0 ? "장소를 선택하세요." : selectedLocation.place_name}
+                </InputPlaceName>
                 <LocationButton onClick={onClickLocationBtn}>
                   <img src="/icons/location.svg" width="100%" />
                 </LocationButton>
@@ -160,7 +163,9 @@ const UploadInfoModal = ({ changeMode, files }: UploadInfoModalProps) => {
               />
             </SearchContainer>
           </ModalHeader>
-          {searchResult.length && <SearchResult searchResult={searchResult} />}
+          {!!searchResult.length && (
+            <SearchResult searchResult={searchResult} setSelectedLocation={setSelectedLocation} />
+          )}
         </ModalSub>
       )}
     </ModalContainer>
@@ -203,6 +208,7 @@ const InputPlaceName = styled.div`
   margin-right: 30px;
   flex-basis: 90%;
   text-align: right;
+  color: ${COLOR.DARKGRAY};
 `;
 const InputBottom = styled.div`
   position: relative;

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
@@ -25,7 +25,11 @@ const UploadInfoModal = ({ changeMode, files }: UploadInfoModalProps) => {
   const [text, setText] = useState<string>("");
   const [activate, setActivate] = useState<boolean>(false);
   const [isSubOpened, setIsSubOpened] = useState(false);
+  const [searchKeyword, setSearchKeyword] = useState<string>("");
+  const [searchResult, setSearchResult] = useState<IData[]>([]);
   const [selectedLocation, setSelectedLocation] = useState<IData>({});
+  const [page, setPage] = useState<number>(1);
+  const [lastPage, setLastPage] = useState<number>(1);
   const highlightsRef = useRef() as React.MutableRefObject<HTMLDivElement>;
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const backdropRef = useRef<HTMLDivElement>(null);
@@ -60,7 +64,7 @@ const UploadInfoModal = ({ changeMode, files }: UploadInfoModalProps) => {
   };
 
   const onClickLocationBtn = () => {
-    setIsSubOpened((prev) => !prev);
+    setIsSubOpened(true);
   };
 
   useEffect(() => {
@@ -117,7 +121,20 @@ const UploadInfoModal = ({ changeMode, files }: UploadInfoModalProps) => {
         </ModalContent>
       </ModalMain>
 
-      {isSubOpened && <ModalSub setIsSubOpened={setIsSubOpened} setSelectedLocation={setSelectedLocation} />}
+      {isSubOpened && (
+        <ModalSub
+          searchKeyword={searchKeyword}
+          setSearchKeyword={setSearchKeyword}
+          setIsSubOpened={setIsSubOpened}
+          setSelectedLocation={setSelectedLocation}
+          searchResult={searchResult}
+          setSearchResult={setSearchResult}
+          page={page}
+          setPage={setPage}
+          lastPage={lastPage}
+          setLastPage={setLastPage}
+        />
+      )}
     </ModalContainer>
   );
 };

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
@@ -203,7 +203,7 @@ const ModalRight = styled.div`
 
   & > .backdrop {
     z-index: 1;
-    background-color: #fff;
+    background-color: ${COLOR.WHITE};
     pointer-events: none;
     font-size: 1.2rem;
     line-height: 1rem;


### PR DESCRIPTION
## 작업 내용
### 장소 검색 기능을 구현
![video1](https://user-images.githubusercontent.com/50266862/140952145-73d048e9-9c22-4e84-b399-401c6280fb3c.gif)

## 고민한 부분

### 1. 장소 검색 (네이버 맵 API vs 카카오 맵 API)
아래와 같은 이유로 장소 검색 기능에서 카카오 맵 API를 사용했음.
- 카카오 맵 API가 더 많은 결과 리스트를 응답한다(네이버 : 최대 5건, 카카오 : 최대 45건)는 이유로 선택.
- 카카오 맵 API가 좀 더 유연한 검색어를 허용함. 예를 들어, **신촌휴먼시아**라는 아파트를 검색했을 때, 네이버 API에는 결과가 없지만, 카카오 API에는 결과가 존재함. (아래 사진에서 위가 네이버 맵 API, 아래가 카카오 맵 API)
    ![스크린샷 2021-11-10 오전 12 19 17](https://user-images.githubusercontent.com/50266862/140951805-795829ca-cb5c-42c2-8b6e-a152e0f56460.png)
    ![스크린샷 2021-11-10 오전 12 20 02](https://user-images.githubusercontent.com/50266862/140951938-df97b374-deb7-4d02-ab17-fa22159e1fd5.png)

### 2. input 태그에 value props를 줄 거면, onChange도 같이 설정해 주어야 한다.

![스크린샷 2021-11-10 오전 12 23 14](https://user-images.githubusercontent.com/50266862/140952500-0d214985-19ef-4a64-85cf-fb49fe7cf5a7.png)

- 기존에는 input 태그에 `keydown` 핸들러만 등록해서 장소 입력을 처리했다.
- 리팩토링하면서 자식 컴포넌트 관계를 설정했다. 그러면서 props로 input 태그 내부의 `value` 값을 넘겨준 뒤, 지정해주려고 했으나 `change` 핸들러를 설정해줘야 한다고 typescript가 에러를 냈다.
- `change` 핸들러를 설정해주고, state 값을 하나 더 추가해서 해결했다.

## 리뷰 포인트


## 관련된 이슈 넘버
#90 