### PR TITLE
사이드바 드래그/드랍 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import { useSelector } from "react-redux";
 import { RootState } from "@src/reducer";
 
 function App() {
-  const { nowTheme }: any = useSelector((state: RootState) => state.theme);
+  const { nowTheme } = useSelector((state: RootState) => state.theme);
   return (
     <>
       <ThemeProvider theme={nowTheme}>

--- a/frontend/src/action/GroupAction.ts
+++ b/frontend/src/action/GroupAction.ts
@@ -2,7 +2,8 @@ const groupAction = {
   ADD_GROUP: "ADD_GROUP",
   SET_SELECTED_GROUP: "SET_SELECTED_GROUP",
   DELETE_GROUP: "DELETE_GROUP",
-  SET_ALL_GROUPS: "SET_ALL_GROUPS",
+  // SET_ALL_GROUPS: "SET_ALL_GROUPS",
+  MOVE_POST: "MOVE_POST",
 };
 
 export default groupAction;

--- a/frontend/src/components/Sidebar/FirstDepth/Group/index.tsx
+++ b/frontend/src/components/Sidebar/FirstDepth/Group/index.tsx
@@ -11,16 +11,39 @@ interface GroupProps {
   groupID: number;
   groupName: string;
   groupImg: string;
-  albumList: Array<{ albumID: number; albumName: string; posts: Array<{ postID: number; postTitle: string }> }>;
   DragHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
   DragEndHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
 }
 
-const Group = ({ setIsToggle, groupID, groupName, groupImg, albumList, DragHandler, DragEndHandler }: GroupProps) => {
+const Group = ({ setIsToggle, groupID, groupName, groupImg, DragHandler, DragEndHandler }: GroupProps) => {
   const dispatch = useDispatch();
   const { selectedGroup }: any = useSelector((state: RootState) => state.groups);
 
   const onClickGroup = () => {
+    const albumList = [
+      {
+        albumID: 0,
+        albumName: "기본 앨범",
+        posts: [
+          { postID: 4, postTitle: "스타벅스 리저브" },
+          { postID: 5, postTitle: "롯데백화점" },
+        ],
+      },
+      {
+        albumID: 1,
+        albumName: "일상 데이트",
+        posts: [
+          { postID: 0, postTitle: "돼지세끼" },
+          { postID: 1, postTitle: "미삼집" },
+          { postID: 2, postTitle: "남산서울타워" },
+        ],
+      },
+      {
+        albumID: 2,
+        albumName: "2020 일본 여행",
+        posts: [{ postID: 3, postTitle: "후쿠오카" }],
+      },
+    ];
     dispatch({ type: GroupAction.SET_SELECTED_GROUP, payload: { groupID, groupName, groupImg, albumList } });
     setIsToggle(true);
   };
@@ -51,6 +74,7 @@ const ButtonWrapper = styled.div<{ selectedGroupID: number; groupID: number; gro
   background-size: 100%;
   cursor: pointer;
   background-repeat: no-repeat;
+  background-position: center;
 `;
 
 export default Group;

--- a/frontend/src/components/Sidebar/FirstDepth/Group/index.tsx
+++ b/frontend/src/components/Sidebar/FirstDepth/Group/index.tsx
@@ -12,9 +12,11 @@ interface GroupProps {
   groupName: string;
   groupImg: string;
   albumList: Array<{ albumID: number; albumName: string; posts: Array<{ postID: number; postTitle: string }> }>;
+  DragHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
+  DragEndHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
 }
 
-const Group = ({ setIsToggle, groupID, groupName, groupImg, albumList }: GroupProps) => {
+const Group = ({ setIsToggle, groupID, groupName, groupImg, albumList, DragHandler, DragEndHandler }: GroupProps) => {
   const dispatch = useDispatch();
   const { selectedGroup }: any = useSelector((state: RootState) => state.groups);
 
@@ -25,9 +27,12 @@ const Group = ({ setIsToggle, groupID, groupName, groupImg, albumList }: GroupPr
 
   return (
     <ButtonWrapper
+      draggable={true}
       selectedGroupID={selectedGroup ? selectedGroup.groupID : -1}
       groupID={groupID}
       groupImg={groupImg}
+      onDrag={DragHandler}
+      onDragEnd={DragEndHandler}
       onClick={onClickGroup}
     ></ButtonWrapper>
   );

--- a/frontend/src/components/Sidebar/FirstDepth/index.tsx
+++ b/frontend/src/components/Sidebar/FirstDepth/index.tsx
@@ -15,30 +15,59 @@ interface FirstDepthProps {
 const FirstDepth = ({ isToggle, setIsToggle, addGroupBtnRef }: FirstDepthProps) => {
   const { groups }: any = useSelector((state: RootState) => state.groups);
 
-  const onClickMenu = () => {
-    setIsToggle((prev) => !prev);
-  };
+  function handleDrag(ev: React.DragEvent<HTMLDivElement>) {
+    const selectedItem = ev.target as HTMLElement;
+    const list = selectedItem.parentNode;
+    if (!list) return;
+    console.log(selectedItem);
+    const x = ev.clientX;
+    const y = ev.clientY;
+    selectedItem.classList.add("drag-sort-active");
+    let swapItem: Element | null =
+      document.elementFromPoint(x, y) === null ? selectedItem : document.elementFromPoint(x, y);
+    if (!swapItem) return;
 
-  useEffect(() => {}, [groups]);
+    if (list === swapItem.parentNode) {
+      const insertItem = swapItem !== selectedItem.nextSibling ? swapItem : swapItem.nextSibling;
+      list.insertBefore(selectedItem, insertItem);
+    }
+  }
+
+  function handleDrop(ev: React.DragEvent<HTMLDivElement>) {
+    const item = ev.target as HTMLElement;
+    item.classList.remove("drag-sort-active");
+  }
 
   return (
     <>
       <FirstDepthWrapper>
-        {groups.map((group: any) => (
-          <Group
-            key={group.groupID}
-            groupID={group.groupID}
-            groupName={group.groupName}
-            groupImg={group.groupImg}
-            albumList={group.albumList}
-            setIsToggle={setIsToggle}
-          />
-        ))}
+        <DraggableWrapper>
+          {groups.map((group: any) => (
+            <Group
+              key={group.groupID}
+              groupID={group.groupID}
+              groupName={group.groupName}
+              groupImg={group.groupImg}
+              albumList={group.albumList}
+              setIsToggle={setIsToggle}
+              DragHandler={handleDrag}
+              DragEndHandler={handleDrop}
+            />
+          ))}
+        </DraggableWrapper>
         <AddGroupButton addGroupBtnRef={addGroupBtnRef} />
       </FirstDepthWrapper>
     </>
   );
 };
+
+const DraggableWrapper = styled.div`
+  & > .drag-sort-active {
+    background: transparent;
+    color: transparent;
+    border: 1px solid #4ca1af;
+  }
+`;
 
 const FirstDepthWrapper = styled.div`
   width: 5vw;

--- a/frontend/src/components/Sidebar/FirstDepth/index.tsx
+++ b/frontend/src/components/Sidebar/FirstDepth/index.tsx
@@ -19,7 +19,6 @@ const FirstDepth = ({ isToggle, setIsToggle, addGroupBtnRef }: FirstDepthProps) 
     const selectedItem = ev.target as HTMLElement;
     const list = selectedItem.parentNode;
     if (!list) return;
-    console.log(selectedItem);
     const x = ev.clientX;
     const y = ev.clientY;
     selectedItem.classList.add("drag-sort-active");

--- a/frontend/src/components/Sidebar/FirstDepth/index.tsx
+++ b/frontend/src/components/Sidebar/FirstDepth/index.tsx
@@ -62,6 +62,7 @@ const FirstDepth = ({ isToggle, setIsToggle, addGroupBtnRef }: FirstDepthProps) 
 };
 
 const DraggableWrapper = styled.div`
+  width: 100%;
   & > .drag-sort-active {
     background: transparent;
     color: transparent;

--- a/frontend/src/components/Sidebar/FirstDepth/index.tsx
+++ b/frontend/src/components/Sidebar/FirstDepth/index.tsx
@@ -47,7 +47,6 @@ const FirstDepth = ({ isToggle, setIsToggle, addGroupBtnRef }: FirstDepthProps) 
               groupID={group.groupID}
               groupName={group.groupName}
               groupImg={group.groupImg}
-              albumList={group.albumList}
               setIsToggle={setIsToggle}
               DragHandler={handleDrag}
               DragEndHandler={handleDrop}

--- a/frontend/src/components/Sidebar/SecondDepth/AddAlbum/InputModal/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AddAlbum/InputModal/index.tsx
@@ -18,22 +18,23 @@ const InputModal = ({ addAlbumModalRef, setIsAddAlbumModalOpened }: InputModalPr
   const dispatch = useDispatch();
 
   const onClickAddAlbum = () => {
-    if (!inputRef.current) return;
+    console.log("로직 수정 예정");
+    // if (!inputRef.current) return;
 
-    const albumName = inputRef.current.value;
-    const selectedGroupID = selectedGroup.groupID;
-    const selectedAlbumList = groups[selectedGroupID].albumList;
-    const albumID = selectedAlbumList[selectedAlbumList.length - 1].albumID + 1;
+    // const albumName = inputRef.current.value;
+    // const selectedGroupID = selectedGroup.groupID;
+    // const selectedAlbumList = groups[selectedGroupID].albumList;
+    // const albumID = selectedAlbumList[selectedAlbumList.length - 1].albumID + 1;
 
-    const newAlbum = {
-      albumID,
-      albumName,
-      posts: [],
-    };
+    // const newAlbum = {
+    //   albumID,
+    //   albumName,
+    //   posts: [],
+    // };
 
-    selectedAlbumList.push(newAlbum);
+    // selectedAlbumList.push(newAlbum);
 
-    dispatch({ type: GroupAction.SET_ALL_GROUPS, payload: groups });
+    // dispatch({ type: GroupAction.SET_ALL_GROUPS, payload: groups });
     setIsAddAlbumModalOpened(false);
   };
 

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Album/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Album/index.tsx
@@ -8,9 +8,19 @@ interface AlbumProps {
   setPostSelected: React.Dispatch<React.SetStateAction<number>>;
   modalOpenedIdx: number;
   setModalOpenedIdx: React.Dispatch<React.SetStateAction<number>>;
+  DragHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
+  DragEndHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
 }
 
-const Album = ({ album, postSelected, setPostSelected, modalOpenedIdx, setModalOpenedIdx }: AlbumProps) => {
+const Album = ({
+  album,
+  postSelected,
+  setPostSelected,
+  modalOpenedIdx,
+  setModalOpenedIdx,
+  DragHandler,
+  DragEndHandler,
+}: AlbumProps) => {
   const [postToggle, setPostToggle] = useState(true);
 
   return (
@@ -22,6 +32,8 @@ const Album = ({ album, postSelected, setPostSelected, modalOpenedIdx, setModalO
         setPostToggle={setPostToggle}
         modalOpenedIdx={modalOpenedIdx}
         setModalOpenedIdx={setModalOpenedIdx}
+        DragHandler={DragHandler}
+        DragEndHandler={DragEndHandler}
       ></Header>
       {postToggle &&
         album.posts.map((post: any) => (

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Album/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Album/index.tsx
@@ -8,10 +8,12 @@ interface AlbumProps {
   setPostSelected: React.Dispatch<React.SetStateAction<number>>;
   modalOpenedIdx: number;
   setModalOpenedIdx: React.Dispatch<React.SetStateAction<number>>;
-  DragOverHander: (ev: React.DragEvent<HTMLDivElement>) => void;
-  DragLeaveHander: (ev: React.DragEvent<HTMLDivElement>) => void;
-  DragEndHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
+  AlbumDragEndHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
+  PostDragEndHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
+  DragLeaveHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
   DropHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
+  PostDragHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
+  AlbumDragHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
 }
 
 const Album = ({
@@ -20,15 +22,17 @@ const Album = ({
   setPostSelected,
   modalOpenedIdx,
   setModalOpenedIdx,
-  DragOverHander,
-  DragLeaveHander,
-  DragEndHandler,
+  AlbumDragEndHandler,
+  PostDragEndHandler,
   DropHandler,
+  PostDragHandler,
+  AlbumDragHandler,
+  DragLeaveHandler,
 }: AlbumProps) => {
   const [postToggle, setPostToggle] = useState(true);
 
   return (
-    <div onDragOver={DragOverHander} onDragLeave={DragLeaveHander} onDragEnd={DragEndHandler} onDrop={DropHandler}>
+    <div onDrop={DropHandler} onDragLeave={DragLeaveHandler}>
       <Header
         albumID={album.albumID}
         albumName={album.albumName}
@@ -36,6 +40,8 @@ const Album = ({
         setPostToggle={setPostToggle}
         modalOpenedIdx={modalOpenedIdx}
         setModalOpenedIdx={setModalOpenedIdx}
+        AlbumDragHandler={AlbumDragHandler}
+        DragEndHandler={AlbumDragEndHandler}
       ></Header>
       {postToggle &&
         album.posts.map((post: any) => (
@@ -45,6 +51,8 @@ const Album = ({
             postSelected={postSelected}
             postTitle={post.postTitle}
             setPostSelected={setPostSelected}
+            PostDragHandler={PostDragHandler}
+            PostDragEndHandler={PostDragEndHandler}
           />
         ))}
     </div>

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Album/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Album/index.tsx
@@ -3,6 +3,7 @@ import Header from "@components/Sidebar/SecondDepth/AlbumList/Header";
 import Post from "@components/Sidebar/SecondDepth/AlbumList/Post";
 
 interface AlbumProps {
+  albumIdx: number;
   album: any;
   postSelected: number;
   setPostSelected: React.Dispatch<React.SetStateAction<number>>;
@@ -17,6 +18,7 @@ interface AlbumProps {
 }
 
 const Album = ({
+  albumIdx,
   album,
   postSelected,
   setPostSelected,
@@ -53,6 +55,7 @@ const Album = ({
             setPostSelected={setPostSelected}
             PostDragHandler={PostDragHandler}
             PostDragEndHandler={PostDragEndHandler}
+            albumIdx={albumIdx}
           />
         ))}
     </div>

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Album/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Album/index.tsx
@@ -8,8 +8,10 @@ interface AlbumProps {
   setPostSelected: React.Dispatch<React.SetStateAction<number>>;
   modalOpenedIdx: number;
   setModalOpenedIdx: React.Dispatch<React.SetStateAction<number>>;
-  DragHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
+  DragOverHander: (ev: React.DragEvent<HTMLDivElement>) => void;
+  DragLeaveHander: (ev: React.DragEvent<HTMLDivElement>) => void;
   DragEndHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
+  DropHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
 }
 
 const Album = ({
@@ -18,13 +20,15 @@ const Album = ({
   setPostSelected,
   modalOpenedIdx,
   setModalOpenedIdx,
-  DragHandler,
+  DragOverHander,
+  DragLeaveHander,
   DragEndHandler,
+  DropHandler,
 }: AlbumProps) => {
   const [postToggle, setPostToggle] = useState(true);
 
   return (
-    <>
+    <div onDragOver={DragOverHander} onDragLeave={DragLeaveHander} onDragEnd={DragEndHandler} onDrop={DropHandler}>
       <Header
         albumID={album.albumID}
         albumName={album.albumName}
@@ -32,8 +36,6 @@ const Album = ({
         setPostToggle={setPostToggle}
         modalOpenedIdx={modalOpenedIdx}
         setModalOpenedIdx={setModalOpenedIdx}
-        DragHandler={DragHandler}
-        DragEndHandler={DragEndHandler}
       ></Header>
       {postToggle &&
         album.posts.map((post: any) => (
@@ -45,7 +47,7 @@ const Album = ({
             setPostSelected={setPostSelected}
           />
         ))}
-    </>
+    </div>
   );
 };
 

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Header/Modal/InnerModal/DeleteAlbumModal.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Header/Modal/InnerModal/DeleteAlbumModal.tsx
@@ -21,21 +21,22 @@ const DeleteAlbumModal = () => {
   };
 
   const onClickDeleteBtn = () => {
-    const { groupID, groupName, groupImg } = selectedGroup;
-    const selectedAlbumList = groups[groupID].albumList;
+    console.log("로직 변경 예정");
+    //   const { groupID, groupName, groupImg } = selectedGroup;
+    //   const selectedAlbumList = groups[groupID].albumList;
 
-    groups[groupID].albumList = selectedAlbumList.filter((album: any) => album.albumID !== selectedAlbum.albumID);
+    //   groups[groupID].albumList = selectedAlbumList.filter((album: any) => album.albumID !== selectedAlbum.albumID);
 
-    const newGroup = {
-      groupID,
-      groupName,
-      groupImg,
-      albumList: groups[groupID].albumList,
-    };
+    //   const newGroup = {
+    //     groupID,
+    //     groupName,
+    //     groupImg,
+    //     albumList: groups[groupID].albumList,
+    //   };
 
-    dispatch({ type: GroupAction.SET_ALL_GROUPS, payload: groups });
-    dispatch({ type: GroupAction.SET_SELECTED_GROUP, payload: newGroup });
-    closeModal();
+    //   dispatch({ type: GroupAction.SET_ALL_GROUPS, payload: groups });
+    //   dispatch({ type: GroupAction.SET_SELECTED_GROUP, payload: newGroup });
+    //   closeModal();
   };
 
   return (

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Header/Modal/InnerModal/UpdateAlbumModal.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Header/Modal/InnerModal/UpdateAlbumModal.tsx
@@ -19,17 +19,18 @@ const UpdateAlbumModal = () => {
   };
 
   const onClickSave = () => {
-    if (!inputRef.current) return;
+    console.log("로직 수정 예정");
+    // if (!inputRef.current) return;
 
-    const selectedGroupID = selectedGroup.groupID;
-    const selectedAlbumList = groups[selectedGroupID].albumList;
-    const albumID = selectedAlbum.albumID;
-    const albumName = inputRef.current.value;
-    const targetIdx = selectedAlbumList.findIndex((album: any) => album.albumID === albumID);
+    // const selectedGroupID = selectedGroup.groupID;
+    // const selectedAlbumList = groups[selectedGroupID].albumList;
+    // const albumID = selectedAlbum.albumID;
+    // const albumName = inputRef.current.value;
+    // const targetIdx = selectedAlbumList.findIndex((album: any) => album.albumID === albumID);
 
-    selectedAlbumList[targetIdx].albumName = albumName;
+    // selectedAlbumList[targetIdx].albumName = albumName;
 
-    dispatch({ type: GroupAction.SET_ALL_GROUPS, payload: groups });
+    // dispatch({ type: GroupAction.SET_ALL_GROUPS, payload: groups });
     closeModal();
   };
 

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Header/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Header/index.tsx
@@ -13,20 +13,9 @@ interface HeaderProps {
   setPostToggle: React.Dispatch<React.SetStateAction<boolean>>;
   modalOpenedIdx: number;
   setModalOpenedIdx: React.Dispatch<React.SetStateAction<number>>;
-  DragHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
-  DragEndHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
 }
 
-const Header = ({
-  albumID,
-  albumName,
-  postToggle,
-  setPostToggle,
-  modalOpenedIdx,
-  setModalOpenedIdx,
-  DragHandler,
-  DragEndHandler,
-}: HeaderProps) => {
+const Header = ({ albumID, albumName, postToggle, setPostToggle, modalOpenedIdx, setModalOpenedIdx }: HeaderProps) => {
   const { nowTheme }: any = useSelector((state: RootState) => state.theme);
 
   const onClickArrowDown = () => {
@@ -38,7 +27,7 @@ const Header = ({
   };
 
   return (
-    <HeaderWrapper onDrag={DragHandler} onDragEnd={DragEndHandler} draggable={true}>
+    <HeaderWrapper draggable={true}>
       <ArrowIcon onClick={onClickArrowDown}>
         {postToggle && <ArrowDownSVG fill={nowTheme.MENUTEXT} />}
         {!postToggle && <ArrowRightSVG fill={nowTheme.MENUTEXT} />}

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Header/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Header/index.tsx
@@ -60,7 +60,7 @@ const HeaderWrapper = styled.div`
   font-weight: bold;
   display: grid;
   grid-template-columns: 10% 80% 10%;
-  cursor: default;
+  cursor: grab;
 `;
 
 const ArrowIcon = styled.div`

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Header/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Header/index.tsx
@@ -13,9 +13,20 @@ interface HeaderProps {
   setPostToggle: React.Dispatch<React.SetStateAction<boolean>>;
   modalOpenedIdx: number;
   setModalOpenedIdx: React.Dispatch<React.SetStateAction<number>>;
+  AlbumDragHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
+  DragEndHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
 }
 
-const Header = ({ albumID, albumName, postToggle, setPostToggle, modalOpenedIdx, setModalOpenedIdx }: HeaderProps) => {
+const Header = ({
+  albumID,
+  albumName,
+  postToggle,
+  setPostToggle,
+  modalOpenedIdx,
+  setModalOpenedIdx,
+  AlbumDragHandler,
+  DragEndHandler,
+}: HeaderProps) => {
   const { nowTheme }: any = useSelector((state: RootState) => state.theme);
 
   const onClickArrowDown = () => {
@@ -27,7 +38,7 @@ const Header = ({ albumID, albumName, postToggle, setPostToggle, modalOpenedIdx,
   };
 
   return (
-    <HeaderWrapper draggable={true}>
+    <HeaderWrapper draggable={true} onDrag={AlbumDragHandler} onDragEnd={DragEndHandler} className={"albumTitle"}>
       <ArrowIcon onClick={onClickArrowDown}>
         {postToggle && <ArrowDownSVG fill={nowTheme.MENUTEXT} />}
         {!postToggle && <ArrowRightSVG fill={nowTheme.MENUTEXT} />}

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Header/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Header/index.tsx
@@ -13,9 +13,20 @@ interface HeaderProps {
   setPostToggle: React.Dispatch<React.SetStateAction<boolean>>;
   modalOpenedIdx: number;
   setModalOpenedIdx: React.Dispatch<React.SetStateAction<number>>;
+  DragHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
+  DragEndHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
 }
 
-const Header = ({ albumID, albumName, postToggle, setPostToggle, modalOpenedIdx, setModalOpenedIdx }: HeaderProps) => {
+const Header = ({
+  albumID,
+  albumName,
+  postToggle,
+  setPostToggle,
+  modalOpenedIdx,
+  setModalOpenedIdx,
+  DragHandler,
+  DragEndHandler,
+}: HeaderProps) => {
   const { nowTheme }: any = useSelector((state: RootState) => state.theme);
 
   const onClickArrowDown = () => {
@@ -27,7 +38,7 @@ const Header = ({ albumID, albumName, postToggle, setPostToggle, modalOpenedIdx,
   };
 
   return (
-    <HeaderWrapper>
+    <HeaderWrapper onDrag={DragHandler} onDragEnd={DragEndHandler} draggable={true}>
       <ArrowIcon onClick={onClickArrowDown}>
         {postToggle && <ArrowDownSVG fill={nowTheme.MENUTEXT} />}
         {!postToggle && <ArrowRightSVG fill={nowTheme.MENUTEXT} />}

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Post/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Post/index.tsx
@@ -4,6 +4,7 @@ import COLOR from "@styles/Color";
 
 interface PostProps {
   idx: number;
+  albumIdx: number;
   postSelected: number;
   postTitle: string;
   setPostSelected: Dispatch<SetStateAction<number>>;
@@ -11,7 +12,15 @@ interface PostProps {
   PostDragEndHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
 }
 
-const Post = ({ idx, postTitle, postSelected, setPostSelected, PostDragHandler, PostDragEndHandler }: PostProps) => {
+const Post = ({
+  idx,
+  postTitle,
+  postSelected,
+  setPostSelected,
+  PostDragHandler,
+  PostDragEndHandler,
+  albumIdx,
+}: PostProps) => {
   const onClickPost = () => {
     setPostSelected(idx);
   };
@@ -25,6 +34,8 @@ const Post = ({ idx, postTitle, postSelected, setPostSelected, PostDragHandler, 
       onDrag={PostDragHandler}
       draggable={true}
       onDragEnd={PostDragEndHandler}
+      data-id={idx}
+      data-albumidx={albumIdx}
     >
       {postTitle}
     </PostWrapper>

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Post/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Post/index.tsx
@@ -7,15 +7,25 @@ interface PostProps {
   postSelected: number;
   postTitle: string;
   setPostSelected: Dispatch<SetStateAction<number>>;
+  PostDragHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
+  PostDragEndHandler: (ev: React.DragEvent<HTMLDivElement>) => void;
 }
 
-const Post = ({ idx, postTitle, postSelected, setPostSelected }: PostProps) => {
+const Post = ({ idx, postTitle, postSelected, setPostSelected, PostDragHandler, PostDragEndHandler }: PostProps) => {
   const onClickPost = () => {
     setPostSelected(idx);
   };
 
   return (
-    <PostWrapper idx={idx} postSelected={postSelected} onClick={onClickPost}>
+    <PostWrapper
+      className="postItem"
+      idx={idx}
+      postSelected={postSelected}
+      onClick={onClickPost}
+      onDrag={PostDragHandler}
+      draggable={true}
+      onDragEnd={PostDragEndHandler}
+    >
       {postTitle}
     </PostWrapper>
   );

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/index.tsx
@@ -10,29 +10,42 @@ const AlbumList = () => {
   const { selectedGroup }: any = useSelector((state: RootState) => state.groups);
   const clickedTarget = useSelector((state: RootState) => state.groupModal.clickedTarget);
 
-  function handleDrag(ev: React.DragEvent<HTMLDivElement>) {
-    const selectedItem = ev.target as HTMLElement;
-    const parentItem = selectedItem.parentNode as HTMLElement;
-    const list = parentItem?.parentNode;
+  function onDragOverHandler(ev: React.DragEvent<HTMLDivElement>) {
+    ev.preventDefault();
+    const target = ev.target as HTMLElement;
+    const parent = target.closest(".AlbumItem");
+    if (!parent) return;
+    parent?.classList.add("drag-hover");
+  }
+
+  function onDragLeaveHandler(ev: React.DragEvent<HTMLDivElement>) {
+    const target = ev.target as HTMLElement;
+    const parent = target.closest(".AlbumItem");
+    if (!parent) return;
+    parent?.classList.remove("drag-hover");
+  }
+  function onDropHandler(ev: React.DragEvent<HTMLDivElement>) {
+    const target = ev.target as HTMLElement;
+    const parent = target.closest(".AlbumItem");
+    if (!parent) return;
+    parent?.classList.remove("drag-hover");
+  }
+
+  function onDragEndHandler(ev: React.DragEvent<HTMLDivElement>) {
+    const target = ev.target as HTMLElement;
+    const parent = target.closest(".AlbumItem");
+    if (!parent) return;
+    const list = parent?.parentNode;
     if (!list) return;
     const x = ev.clientX;
     const y = ev.clientY;
-    parentItem.classList.add("drag-sort-active");
-    let swapItem: Element | null =
-      document.elementFromPoint(x, y) === null ? parentItem : document.elementFromPoint(x, y);
+    let swapItem: Element | null = document.elementFromPoint(x, y) === null ? parent : document.elementFromPoint(x, y);
     if (!swapItem) return;
     swapItem = swapItem.closest(".AlbumItem");
-    if (swapItem !== parentItem && list === swapItem?.parentNode) {
-      const referenceNode = swapItem !== parentItem.nextSibling ? swapItem : swapItem.nextSibling;
-      list.insertBefore(parentItem, referenceNode);
+    if (swapItem !== parent && list === swapItem?.parentNode) {
+      const referenceNode = swapItem !== parent.nextSibling ? swapItem : swapItem.nextSibling;
+      list.insertBefore(parent, referenceNode);
     }
-  }
-
-  function handleDrop(ev: React.DragEvent<HTMLDivElement>) {
-    const item = ev.target as HTMLElement;
-    const parentItem = item.closest(".drag-sort-active");
-    if (!parentItem) return;
-    parentItem.classList.remove("drag-sort-active");
   }
 
   useEffect(() => {
@@ -62,8 +75,10 @@ const AlbumList = () => {
                 setPostSelected={setPostSelected}
                 modalOpenedIdx={modalOpenedIdx}
                 setModalOpenedIdx={setModalOpenedIdx}
-                DragHandler={handleDrag}
-                DragEndHandler={handleDrop}
+                DragOverHander={onDragOverHandler}
+                DragLeaveHander={onDragLeaveHandler}
+                DragEndHandler={onDragEndHandler}
+                DropHandler={onDropHandler}
               ></Album>
             </AlbumWrapper>
           );
@@ -74,9 +89,8 @@ const AlbumList = () => {
 
 const DraggableWrapper = styled.div`
   width: 100%;
-  & .drag-sort-active {
-    background: transparent;
-    border: 1px solid ${(props) => props.theme.MENUTEXT};
+  & .drag-hover {
+    border-top: 1px solid ${(props) => props.theme.MENUTEXT};
   }
 `;
 const AlbumWrapper = styled.div`

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/index.tsx
@@ -5,10 +5,35 @@ import { RootState } from "@src/reducer";
 import Album from "./Album";
 
 const AlbumList = () => {
-  const [postSelected, setPostSelected] = useState<number>(0);
+  const [postSelected, setPostSelected] = useState<number>(-1);
   const [modalOpenedIdx, setModalOpenedIdx] = useState<number>(-1);
   const { selectedGroup }: any = useSelector((state: RootState) => state.groups);
   const clickedTarget = useSelector((state: RootState) => state.groupModal.clickedTarget);
+
+  function handleDrag(ev: React.DragEvent<HTMLDivElement>) {
+    const selectedItem = ev.target as HTMLElement;
+    const parentItem = selectedItem.parentNode as HTMLElement;
+    const list = parentItem?.parentNode;
+    if (!list) return;
+    const x = ev.clientX;
+    const y = ev.clientY;
+    parentItem.classList.add("drag-sort-active");
+    let swapItem: Element | null =
+      document.elementFromPoint(x, y) === null ? parentItem : document.elementFromPoint(x, y);
+    if (!swapItem) return;
+    swapItem = swapItem.closest(".AlbumItem");
+    if (swapItem !== parentItem && list === swapItem?.parentNode) {
+      const referenceNode = swapItem !== parentItem.nextSibling ? swapItem : swapItem.nextSibling;
+      list.insertBefore(parentItem, referenceNode);
+    }
+  }
+
+  function handleDrop(ev: React.DragEvent<HTMLDivElement>) {
+    const item = ev.target as HTMLElement;
+    const parentItem = item.closest(".drag-sort-active");
+    if (!parentItem) return;
+    parentItem.classList.remove("drag-sort-active");
+  }
 
   useEffect(() => {
     const clickHandler = () => {
@@ -26,30 +51,39 @@ const AlbumList = () => {
   }, [clickedTarget]);
 
   return (
-    <>
+    <DraggableWrapper>
       {selectedGroup.albumList &&
         selectedGroup.albumList.map((album: any) => {
           return (
-            <AlbumWrapper key={album.albumID}>
+            <AlbumWrapper key={album.albumID} className="AlbumItem">
               <Album
                 album={album}
                 postSelected={postSelected}
                 setPostSelected={setPostSelected}
                 modalOpenedIdx={modalOpenedIdx}
                 setModalOpenedIdx={setModalOpenedIdx}
+                DragHandler={handleDrag}
+                DragEndHandler={handleDrop}
               ></Album>
             </AlbumWrapper>
           );
         })}
-    </>
+    </DraggableWrapper>
   );
 };
 
+const DraggableWrapper = styled.div`
+  width: 100%;
+  & .drag-sort-active {
+    background: transparent;
+    border: 1px solid ${(props) => props.theme.MENUTEXT};
+  }
+`;
 const AlbumWrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  margin: 10px 0;
+  margin: 20px 0;
 `;
 
 export default AlbumList;

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/index.tsx
@@ -3,23 +3,26 @@ import styled from "styled-components";
 import { useSelector } from "react-redux";
 import { RootState } from "@src/reducer";
 import Album from "./Album";
+import { GroupAction } from "@src/action";
+import { useDispatch } from "react-redux";
 
 const AlbumList = () => {
+  const dispatch = useDispatch();
   const [postSelected, setPostSelected] = useState<number>(-1);
   const [modalOpenedIdx, setModalOpenedIdx] = useState<number>(-1);
-  const { selectedGroup }: any = useSelector((state: RootState) => state.groups);
+  const { albumList }: any = useSelector((state: RootState) => state.groups);
   const clickedTarget = useSelector((state: RootState) => state.groupModal.clickedTarget);
 
   function onDragLeaveHandler(ev: React.DragEvent<HTMLDivElement>) {
     const target = ev.target as HTMLElement;
-    const parent = target.closest(".AlbumItem");
+    const parent = target.closest(".albumItem");
     if (!parent) return;
     parent?.classList.remove("album-hover");
     parent?.classList.remove("post-hover");
   }
   function onDropHandler(ev: React.DragEvent<HTMLDivElement>) {
     const target = ev.target as HTMLElement;
-    const parent = target.closest(".AlbumItem");
+    const parent = target.closest(".albumItem");
     if (!parent) return;
     parent?.classList.remove("album-hover");
     parent?.classList.remove("post-hover");
@@ -27,7 +30,7 @@ const AlbumList = () => {
 
   function onAlbumDragEndHandler(ev: React.DragEvent<HTMLDivElement>) {
     const target = ev.target as HTMLElement;
-    const parent = target.closest(".AlbumItem");
+    const parent = target.closest(".albumItem");
     if (!parent) return;
     parent?.classList.remove("album-hover");
     parent?.classList.remove("post-hover");
@@ -37,7 +40,7 @@ const AlbumList = () => {
     const y = ev.clientY;
     let swapItem: Element | null = document.elementFromPoint(x, y) === null ? parent : document.elementFromPoint(x, y);
     if (!swapItem) return;
-    swapItem = swapItem.closest(".AlbumItem");
+    swapItem = swapItem.closest(".albumItem");
     if (swapItem !== parent && list === swapItem?.parentNode) {
       const referenceNode = swapItem !== parent.nextSibling ? swapItem : swapItem.nextSibling;
       list.insertBefore(parent, referenceNode);
@@ -46,16 +49,31 @@ const AlbumList = () => {
 
   function onPostDragEndHandler(ev: React.DragEvent<HTMLDivElement>) {
     const target = ev.target as HTMLElement;
-    console.log(target);
+    const parent = target.closest(".albumItem");
+    const x = ev.clientX;
+    const y = ev.clientY;
+    const nowElement = document.elementFromPoint(x, y);
+    const nowParent = nowElement?.closest(".albumItem") as HTMLElement;
+    if (!nowParent) return;
+    if (parent === nowParent) return;
+    const payload = {
+      beforeIdx: target.dataset.albumidx,
+      afterIdx: nowParent.dataset.albumidx,
+      post: { postID: target.dataset.id, postTitle: target.innerHTML },
+    };
+    dispatch({
+      type: GroupAction.MOVE_POST,
+      payload: payload,
+    });
   }
 
   function onPostDragHandler(ev: React.DragEvent<HTMLDivElement>) {
     const target = ev.target as HTMLElement;
-    const parent = target.closest(".AlbumItem");
+    const parent = target.closest(".albumItem");
     const x = ev.clientX;
     const y = ev.clientY;
     const nowElement = document.elementFromPoint(x, y);
-    const nowParent = nowElement?.closest(".AlbumItem");
+    const nowParent = nowElement?.closest(".albumItem");
     if (!nowParent) return;
     if (parent === nowParent) return;
     nowParent.classList.add("post-hover");
@@ -63,11 +81,11 @@ const AlbumList = () => {
 
   function onAlbumDragHandler(ev: React.DragEvent<HTMLDivElement>) {
     const target = ev.target as HTMLElement;
-    const parent = target.closest(".AlbumItem");
+    const parent = target.closest(".albumItem");
     const x = ev.clientX;
     const y = ev.clientY;
     const nowElement = document.elementFromPoint(x, y);
-    const nowParent = nowElement?.closest(".AlbumItem");
+    const nowParent = nowElement?.closest(".albumItem");
     if (!nowParent) return;
     if (parent === nowParent) return;
     nowParent.classList.add("album-hover");
@@ -90,10 +108,10 @@ const AlbumList = () => {
 
   return (
     <DraggableWrapper>
-      {selectedGroup.albumList &&
-        selectedGroup.albumList.map((album: any) => {
+      {albumList &&
+        albumList.map((album: any, idx: number) => {
           return (
-            <AlbumWrapper key={album.albumID} className="AlbumItem">
+            <AlbumWrapper key={album.albumID} className="albumItem" data-albumidx={idx}>
               <Album
                 album={album}
                 postSelected={postSelected}
@@ -106,6 +124,7 @@ const AlbumList = () => {
                 AlbumDragHandler={onAlbumDragHandler}
                 DragLeaveHandler={onDragLeaveHandler}
                 PostDragEndHandler={onPostDragEndHandler}
+                albumIdx={idx}
               ></Album>
             </AlbumWrapper>
           );

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/index.tsx
@@ -10,31 +10,27 @@ const AlbumList = () => {
   const { selectedGroup }: any = useSelector((state: RootState) => state.groups);
   const clickedTarget = useSelector((state: RootState) => state.groupModal.clickedTarget);
 
-  function onDragOverHandler(ev: React.DragEvent<HTMLDivElement>) {
-    ev.preventDefault();
-    const target = ev.target as HTMLElement;
-    const parent = target.closest(".AlbumItem");
-    if (!parent) return;
-    parent?.classList.add("drag-hover");
-  }
-
   function onDragLeaveHandler(ev: React.DragEvent<HTMLDivElement>) {
     const target = ev.target as HTMLElement;
     const parent = target.closest(".AlbumItem");
     if (!parent) return;
-    parent?.classList.remove("drag-hover");
+    parent?.classList.remove("album-hover");
+    parent?.classList.remove("post-hover");
   }
   function onDropHandler(ev: React.DragEvent<HTMLDivElement>) {
     const target = ev.target as HTMLElement;
     const parent = target.closest(".AlbumItem");
     if (!parent) return;
-    parent?.classList.remove("drag-hover");
+    parent?.classList.remove("album-hover");
+    parent?.classList.remove("post-hover");
   }
 
-  function onDragEndHandler(ev: React.DragEvent<HTMLDivElement>) {
+  function onAlbumDragEndHandler(ev: React.DragEvent<HTMLDivElement>) {
     const target = ev.target as HTMLElement;
     const parent = target.closest(".AlbumItem");
     if (!parent) return;
+    parent?.classList.remove("album-hover");
+    parent?.classList.remove("post-hover");
     const list = parent?.parentNode;
     if (!list) return;
     const x = ev.clientX;
@@ -46,6 +42,35 @@ const AlbumList = () => {
       const referenceNode = swapItem !== parent.nextSibling ? swapItem : swapItem.nextSibling;
       list.insertBefore(parent, referenceNode);
     }
+  }
+
+  function onPostDragEndHandler(ev: React.DragEvent<HTMLDivElement>) {
+    const target = ev.target as HTMLElement;
+    console.log(target);
+  }
+
+  function onPostDragHandler(ev: React.DragEvent<HTMLDivElement>) {
+    const target = ev.target as HTMLElement;
+    const parent = target.closest(".AlbumItem");
+    const x = ev.clientX;
+    const y = ev.clientY;
+    const nowElement = document.elementFromPoint(x, y);
+    const nowParent = nowElement?.closest(".AlbumItem");
+    if (!nowParent) return;
+    if (parent === nowParent) return;
+    nowParent.classList.add("post-hover");
+  }
+
+  function onAlbumDragHandler(ev: React.DragEvent<HTMLDivElement>) {
+    const target = ev.target as HTMLElement;
+    const parent = target.closest(".AlbumItem");
+    const x = ev.clientX;
+    const y = ev.clientY;
+    const nowElement = document.elementFromPoint(x, y);
+    const nowParent = nowElement?.closest(".AlbumItem");
+    if (!nowParent) return;
+    if (parent === nowParent) return;
+    nowParent.classList.add("album-hover");
   }
 
   useEffect(() => {
@@ -75,10 +100,12 @@ const AlbumList = () => {
                 setPostSelected={setPostSelected}
                 modalOpenedIdx={modalOpenedIdx}
                 setModalOpenedIdx={setModalOpenedIdx}
-                DragOverHander={onDragOverHandler}
-                DragLeaveHander={onDragLeaveHandler}
-                DragEndHandler={onDragEndHandler}
+                AlbumDragEndHandler={onAlbumDragEndHandler}
                 DropHandler={onDropHandler}
+                PostDragHandler={onPostDragHandler}
+                AlbumDragHandler={onAlbumDragHandler}
+                DragLeaveHandler={onDragLeaveHandler}
+                PostDragEndHandler={onPostDragEndHandler}
               ></Album>
             </AlbumWrapper>
           );
@@ -89,7 +116,10 @@ const AlbumList = () => {
 
 const DraggableWrapper = styled.div`
   width: 100%;
-  & .drag-hover {
+  & .post-hover {
+    border: 2px dotted ${(props) => props.theme.MENUTEXT};
+  }
+  & .album-hover {
     border-top: 1px solid ${(props) => props.theme.MENUTEXT};
   }
 `;

--- a/frontend/src/reducer/GroupReducer.ts
+++ b/frontend/src/reducer/GroupReducer.ts
@@ -78,14 +78,7 @@ const groupReducer = (state = initState, action: any) => {
     case GroupAction.SET_SELECTED_GROUP:
       return {
         ...state,
-        selectedGroup: action.payload
-          ? {
-              groupID: action.payload.groupID,
-              groupName: action.payload.groupName,
-              groupImg: action.payload.groupImg,
-              albumList: action.payload.albumList,
-            }
-          : null,
+        selectedGroup: action.payload ? action.payload : null,
       };
     case GroupAction.DELETE_GROUP:
       return {

--- a/frontend/src/reducer/GroupReducer.ts
+++ b/frontend/src/reducer/GroupReducer.ts
@@ -1,69 +1,34 @@
 import { GroupAction } from "@src/action";
+import AlbumList from "@src/components/Sidebar/SecondDepth/AlbumList";
+
+interface PostType {
+  postID: number;
+  postTitle: string;
+}
+interface AlbumListItemType {
+  albumID: string;
+  albumName: string;
+  posts: PostType[];
+}
 
 const initState = {
   selectedGroup: null,
+  albumList: [],
   groups: [
     {
       groupID: 0,
       groupName: "그룹 A",
       groupImg: "/img/dummy-group1.png",
-      albumList: [
-        {
-          albumID: 0,
-          albumName: "기본 앨범",
-          posts: [
-            { postID: 4, postTitle: "스타벅스 리저브" },
-            { postID: 5, postTitle: "롯데백화점" },
-          ],
-        },
-        {
-          albumID: 1,
-          albumName: "일상 데이트",
-          posts: [
-            { postID: 0, postTitle: "돼지세끼" },
-            { postID: 1, postTitle: "미삼집" },
-            { postID: 2, postTitle: "남산서울타워" },
-          ],
-        },
-        {
-          albumID: 2,
-          albumName: "2020 일본 여행",
-          posts: [{ postID: 3, postTitle: "후쿠오카" }],
-        },
-      ],
     },
     {
       groupID: 1,
       groupName: "그룹 B",
       groupImg: "/img/dummy-group2.png",
-      albumList: [
-        {
-          albumID: 3,
-          albumName: "기본 앨범",
-          posts: [],
-        },
-        {
-          albumID: 4,
-          albumName: "가족 여행",
-          posts: [
-            { postID: 6, postTitle: "대전" },
-            { postID: 7, postTitle: "부산" },
-            { postID: 8, postTitle: "서울" },
-          ],
-        },
-      ],
     },
     {
       groupID: 2,
       groupName: "그룹 C",
       groupImg: "/img/dummy-group3.png",
-      albumList: [
-        {
-          albumID: 5,
-          albumName: "기본 앨범",
-          posts: [],
-        },
-      ],
     },
   ],
 };
@@ -78,18 +43,40 @@ const groupReducer = (state = initState, action: any) => {
     case GroupAction.SET_SELECTED_GROUP:
       return {
         ...state,
-        selectedGroup: action.payload ? action.payload : null,
+        selectedGroup: action.payload
+          ? { groupID: action.payload.groupID, groupName: action.payload.groupName, groupImg: action.payload.groupImg }
+          : null,
+        albumList: action.payload.albumList,
       };
     case GroupAction.DELETE_GROUP:
       return {
         ...state,
-        groups: state.groups.filter((group) => group.groupID !== action.payload.groupID),
+        selectedGroup: state.groups.filter((group) => group.groupID !== action.payload.groupID),
       };
-    case GroupAction.SET_ALL_GROUPS:
+    case GroupAction.MOVE_POST:
+      const beforeIdx = action.payload.beforeIdx;
+      const afterIdx = action.payload.afterIdx;
+      const post = action.payload.post;
+      const newAlbumList = state.albumList.map((album: AlbumListItemType, idx) => {
+        if (idx != beforeIdx) return album;
+        const updateAlbum: AlbumListItemType = {
+          albumID: album.albumID,
+          albumName: album.albumName,
+          posts: [],
+        };
+        updateAlbum.posts = album.posts.filter((now) => now.postID != post.postID);
+        return updateAlbum;
+      });
+      newAlbumList[afterIdx].posts.push(post);
       return {
         ...state,
-        groups: action.payload,
+        albumList: newAlbumList,
       };
+    // case GroupAction.SET_ALL_GROUPS:
+    //   return {
+    //     ...state,
+    //     groups: action.payload,
+    //   };
 
     default:
       return state;


### PR DESCRIPTION
## 작업 내용
![드래그드랍2](https://user-images.githubusercontent.com/34854154/140956979-a1ebc96b-3616-4346-acc6-a06edd3b715e.gif)

1. 그룹 드래그/드랍 순서 변경
2.  앨범 드래그/드랍 순서 변경
3. 포스트 드래그/드랍 앨범 변경 

## 고민한 부분
- 라이브러리 사용 없이 드래그/드랍 구현하기
- DOM 조작 없이 React를 상태를 이용해 리렌더링 할 수 없을지 고민 하였습니다.
    - 그룹과 앨범은 DOM을 조작 하여 순서를 바꿔주는 로직. 
    - 포스트 드래그/드랍을 구현하면서 리액트 상태를 이용해 봤습니다😀 

## 리뷰 포인트
- 리덕스 상태를 바꾸며 사이드이펙트 나는 부분 주석처리 한 점 양해바랍니다. // 추후 로직 변경 예정  
- 리듀서에서 불변성을 유지하기 위해 고차함수를 작성했는데 더 좋은 코드가 있는지.

## 관련된 이슈 넘버
[#91, #93, #94]  
