### PR TITLE
그룹 정보 조회 & 그룹 생성 & 그룹 참가 API 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,8 +3,9 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { typeORMConfig } from "./configs/typeorm.config";
 import { UserModule } from "./user/user.module";
 import { AuthModule } from "./auth/auth.module";
+import { GroupModule } from "./group/group.module";
 
 @Module({
-  imports: [TypeOrmModule.forRoot(typeORMConfig), UserModule, AuthModule],
+  imports: [TypeOrmModule.forRoot(typeORMConfig), UserModule, AuthModule, GroupModule],
 })
 export class AppModule {}

--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -20,7 +20,8 @@ export class AuthController {
     const accessToken = req.user.accessToken;
 
     res.cookie("accessToken", accessToken);
-    res.redirect("/");
+    //res.redirect("/");
+    res.redirect("http://localhost:3000");
     res.end();
   }
 }

--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -20,8 +20,7 @@ export class AuthController {
     const accessToken = req.user.accessToken;
 
     res.cookie("accessToken", accessToken);
-    //res.redirect("/");
-    res.redirect("http://localhost:3000");
+    res.redirect("/");
     res.end();
   }
 }

--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -20,7 +20,7 @@ export class AuthController {
     const accessToken = req.user.accessToken;
 
     res.cookie("accessToken", accessToken);
-    res.redirect("http://localhost:3000");
+    res.redirect("/");
     res.end();
   }
 }

--- a/backend/src/auth/service/auth.service.ts
+++ b/backend/src/auth/service/auth.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@nestjs/common";
-import { RegisterUserDto } from "src/dto/user/register-user.dto";
+import { UserInfoDto } from "src/dto/user/userInfo.dto";
 import { JwtService } from "@nestjs/jwt";
 import { UserService } from "src/user/service/user.service";
 import { User } from "../../user/user.entity";
@@ -8,7 +8,7 @@ import { User } from "../../user/user.entity";
 export class AuthService {
   constructor(private userService: UserService, private jwtService: JwtService) {}
 
-  async validateUser(registerUserDto: RegisterUserDto): Promise<User | undefined> {
+  async validateUser(registerUserDto: UserInfoDto): Promise<User | undefined> {
     const user = await this.userService.registeredUser(registerUserDto);
 
     return user;

--- a/backend/src/auth/strategy/naver.strategy.ts
+++ b/backend/src/auth/strategy/naver.strategy.ts
@@ -1,7 +1,7 @@
 import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
 import { Strategy } from "passport-naver-v2";
-import { RegisterUserDto } from "src/dto/user/register-user.dto";
+import { UserInfoDto } from "src/dto/user/userInfo.dto";
 import { AuthService } from "../service/auth.service";
 
 @Injectable()
@@ -16,7 +16,7 @@ export class NaverStrategy extends PassportStrategy(Strategy, "naver") {
 
   async validate(naverAccessToken: string, naverRefreshToken: string, profile: any): Promise<{ accessToken: string }> {
     const { email, nickname, profileImage } = profile;
-    const registerUserDto: RegisterUserDto = new RegisterUserDto();
+    const registerUserDto: UserInfoDto = new UserInfoDto();
     registerUserDto.userEmail = email;
     registerUserDto.userNickname = nickname;
     registerUserDto.profileImage = profileImage;

--- a/backend/src/dto/group/attendGroupRequest.dto.ts
+++ b/backend/src/dto/group/attendGroupRequest.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsNumber, IsString } from "class-validator";
+
+export class AttendGroupRequestDto {
+  @IsNumber()
+  @IsNotEmpty()
+  userId: number;
+
+  @IsString()
+  @IsNotEmpty()
+  code: string;
+}

--- a/backend/src/dto/group/createGroupRequest.dto.ts
+++ b/backend/src/dto/group/createGroupRequest.dto.ts
@@ -1,5 +1,4 @@
-import { Optional } from "@nestjs/common";
-import { IsNotEmpty, IsNumber, IsString } from "class-validator";
+import { IsNotEmpty, IsNumber, IsString, IsOptional } from "class-validator";
 
 export class CreateGroupRequestDto {
   @IsNumber()
@@ -7,7 +6,7 @@ export class CreateGroupRequestDto {
   userId: number;
 
   @IsString()
-  @Optional()
+  @IsOptional()
   groupImage: string;
 
   @IsString()

--- a/backend/src/dto/group/createGroupRequest.dto.ts
+++ b/backend/src/dto/group/createGroupRequest.dto.ts
@@ -1,0 +1,16 @@
+import { Optional } from "@nestjs/common";
+import { IsNotEmpty, IsNumber, IsString } from "class-validator";
+
+export class CreateGroupRequestDto {
+  @IsNumber()
+  @IsNotEmpty()
+  userId: number;
+
+  @IsString()
+  @Optional()
+  groupImage: string;
+
+  @IsString()
+  @IsNotEmpty()
+  groupName: string;
+}

--- a/backend/src/dto/group/getGroupInfoResponse.dto.ts
+++ b/backend/src/dto/group/getGroupInfoResponse.dto.ts
@@ -1,0 +1,12 @@
+import { IsArray, IsNotEmpty, IsString } from "class-validator";
+import { UserInfoDto } from "../user/userInfo.dto";
+
+export class GetGroupInfoResponseDto {
+  @IsString()
+  @IsNotEmpty()
+  groupCode: string;
+
+  @IsArray()
+  @IsNotEmpty()
+  users: UserInfoDto[];
+}

--- a/backend/src/dto/user/userInfo.dto.ts
+++ b/backend/src/dto/user/userInfo.dto.ts
@@ -1,6 +1,6 @@
 import { IsString, IsNotEmpty, IsOptional } from "class-validator";
 
-export class RegisterUserDto {
+export class UserInfoDto {
   @IsString()
   @IsNotEmpty()
   userEmail: string;

--- a/backend/src/group/controller/group.controller.spec.ts
+++ b/backend/src/group/controller/group.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { GroupController } from "./group.controller";
+
+describe("GroupController", () => {
+  let controller: GroupController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GroupController],
+    }).compile();
+
+    controller = module.get<GroupController>(GroupController);
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/group/controller/group.controller.ts
+++ b/backend/src/group/controller/group.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('group')
+export class GroupController {}

--- a/backend/src/group/controller/group.controller.ts
+++ b/backend/src/group/controller/group.controller.ts
@@ -1,8 +1,9 @@
-import { Body, Controller, HttpCode, Post, UseGuards } from "@nestjs/common";
+import { Body, Controller, Get, HttpCode, Param, Post, UseGuards } from "@nestjs/common";
 import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
 import { GroupService } from "../service/group.service";
 import { CreateGroupRequestDto } from "src/dto/group/createGroupRequest.dto";
 import { AttendGroupRequestDto } from "src/dto/group/attendGroupRequest.dto";
+import { GetGroupInfoResponseDto } from "src/dto/group/getGroupInfoResponse.dto";
 
 @UseGuards(JwtAuthGuard)
 @Controller("api/groups")
@@ -19,5 +20,10 @@ export class GroupController {
   @HttpCode(200)
   AttendGroup(@Body() attendGroupRequestDto: AttendGroupRequestDto): Promise<number> {
     return this.groupService.attendGroup(attendGroupRequestDto);
+  }
+
+  @Get("/:groupId")
+  GetGroupInfo(@Param("groupId") groupId: number): Promise<GetGroupInfoResponseDto> {
+    return this.groupService.getGroupInfo(groupId);
   }
 }

--- a/backend/src/group/controller/group.controller.ts
+++ b/backend/src/group/controller/group.controller.ts
@@ -1,4 +1,4 @@
-import { Controller } from '@nestjs/common';
+import { Controller } from "@nestjs/common";
 
-@Controller('group')
+@Controller("group")
 export class GroupController {}

--- a/backend/src/group/controller/group.controller.ts
+++ b/backend/src/group/controller/group.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, HttpCode, Post, UseGuards } from "@nestjs/common";
 import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
 import { GroupService } from "../service/group.service";
 import { CreateGroupRequestDto } from "src/dto/group/createGroupRequest.dto";
+import { AttendGroupRequestDto } from "src/dto/group/attendGroupRequest.dto";
 
 @UseGuards(JwtAuthGuard)
 @Controller("api/groups")
@@ -12,5 +13,11 @@ export class GroupController {
   @HttpCode(200)
   CreateGroup(@Body() createGroupRequestDto: CreateGroupRequestDto): Promise<number> {
     return this.groupService.createGroup(createGroupRequestDto);
+  }
+
+  @Post("/join")
+  @HttpCode(200)
+  AttendGroup(@Body() attendGroupRequestDto: AttendGroupRequestDto): Promise<number> {
+    return this.groupService.attendGroup(attendGroupRequestDto);
   }
 }

--- a/backend/src/group/controller/group.controller.ts
+++ b/backend/src/group/controller/group.controller.ts
@@ -1,4 +1,16 @@
-import { Controller } from "@nestjs/common";
+import { Body, Controller, HttpCode, Post, UseGuards } from "@nestjs/common";
+import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
+import { GroupService } from "../service/group.service";
+import { CreateGroupRequestDto } from "src/dto/group/createGroupRequest.dto";
 
-@Controller("group")
-export class GroupController {}
+@UseGuards(JwtAuthGuard)
+@Controller("api/groups")
+export class GroupController {
+  constructor(private readonly groupService: GroupService) {}
+
+  @Post()
+  @HttpCode(200)
+  CreateGroup(@Body() createGroupRequestDto: CreateGroupRequestDto): Promise<number> {
+    return this.groupService.createGroup(createGroupRequestDto);
+  }
+}

--- a/backend/src/group/group.entity.ts
+++ b/backend/src/group/group.entity.ts
@@ -1,7 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, Column } from "typeorm";
 import { TimeStampEntity } from "src/myBaseEntity/TimestampEntity";
 
-@Entity()
+@Entity({ name: "groups" })
 export class Group extends TimeStampEntity {
   @PrimaryGeneratedColumn()
   groupId: number;

--- a/backend/src/group/group.entity.ts
+++ b/backend/src/group/group.entity.ts
@@ -1,0 +1,4 @@
+import { Entity, BaseEntity } from "typeorm";
+
+@Entity()
+export class Group extends BaseEntity {}

--- a/backend/src/group/group.entity.ts
+++ b/backend/src/group/group.entity.ts
@@ -1,5 +1,6 @@
-import { Entity, PrimaryGeneratedColumn, Column } from "typeorm";
+import { Entity, PrimaryGeneratedColumn, Column, ManyToMany, JoinTable } from "typeorm";
 import { TimeStampEntity } from "src/myBaseEntity/TimestampEntity";
+import { User } from "src/user/user.entity";
 
 @Entity({ name: "groups_TB" })
 export class Group extends TimeStampEntity {
@@ -14,4 +15,8 @@ export class Group extends TimeStampEntity {
 
   @Column()
   groupCode: string;
+
+  @ManyToMany(() => User)
+  @JoinTable()
+  users: User[];
 }

--- a/backend/src/group/group.entity.ts
+++ b/backend/src/group/group.entity.ts
@@ -17,6 +17,6 @@ export class Group extends TimeStampEntity {
   groupCode: string;
 
   @ManyToMany(() => User)
-  @JoinTable()
+  @JoinTable({ name: "users_groups_TB" })
   users: User[];
 }

--- a/backend/src/group/group.entity.ts
+++ b/backend/src/group/group.entity.ts
@@ -1,7 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, Column } from "typeorm";
 import { TimeStampEntity } from "src/myBaseEntity/TimestampEntity";
 
-@Entity({ name: "groups" })
+@Entity({ name: "groups_TB" })
 export class Group extends TimeStampEntity {
   @PrimaryGeneratedColumn()
   groupId: number;

--- a/backend/src/group/group.entity.ts
+++ b/backend/src/group/group.entity.ts
@@ -1,4 +1,17 @@
-import { Entity, BaseEntity } from "typeorm";
+import { Entity, PrimaryGeneratedColumn, Column } from "typeorm";
+import { TimeStampEntity } from "src/myBaseEntity/TimestampEntity";
 
 @Entity()
-export class Group extends BaseEntity {}
+export class Group extends TimeStampEntity {
+  @PrimaryGeneratedColumn()
+  groupId: number;
+
+  @Column({ nullable: true })
+  groupImage: string;
+
+  @Column()
+  groupName: string;
+
+  @Column()
+  groupCode: string;
+}

--- a/backend/src/group/group.module.ts
+++ b/backend/src/group/group.module.ts
@@ -1,13 +1,14 @@
 import { Module } from "@nestjs/common";
 import { JwtModule } from "@nestjs/jwt";
 import { TypeOrmModule } from "@nestjs/typeorm";
+import { UserRepository } from "src/user/user.repository";
 import { GroupController } from "./controller/group.controller";
 import { GroupRepository } from "./group.repository";
 import { GroupService } from "./service/group.service";
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([GroupRepository]),
+    TypeOrmModule.forFeature([GroupRepository, UserRepository]),
     JwtModule.register({
       secret: process.env.JWT_SECRET,
     }),

--- a/backend/src/group/group.module.ts
+++ b/backend/src/group/group.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { JwtModule } from "@nestjs/jwt";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { GroupController } from "./controller/group.controller";
+import { GroupRepository } from "./group.repository";
+import { GroupService } from "./service/group.service";
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([GroupRepository]),
+    JwtModule.register({
+      secret: process.env.JWT_SECRET,
+    }),
+  ],
+  controllers: [GroupController],
+  providers: [GroupService],
+})
+export class GroupModule {}

--- a/backend/src/group/group.repository.ts
+++ b/backend/src/group/group.repository.ts
@@ -1,0 +1,5 @@
+import { EntityRepository, Repository } from "typeorm";
+import { Group } from "./group.entity";
+
+@EntityRepository(Group)
+export class GroupRepository extends Repository<Group> {}

--- a/backend/src/group/service/group.service.spec.ts
+++ b/backend/src/group/service/group.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { GroupService } from "./group.service";
+
+describe("GroupService", () => {
+  let service: GroupService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GroupService],
+    }).compile();
+
+    service = module.get<GroupService>(GroupService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class GroupService {}

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -1,4 +1,36 @@
 import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { GroupRepository } from "../group.repository";
+import { CreateGroupRequestDto } from "src/dto/group/createGroupRequest.dto";
+import { UserRepository } from "src/user/user.repository";
 
 @Injectable()
-export class GroupService {}
+export class GroupService {
+  constructor(
+    @InjectRepository(GroupRepository)
+    private groupRepository: GroupRepository,
+    @InjectRepository(UserRepository)
+    private userRepository: UserRepository,
+  ) {}
+
+  async createGroup(createGroupRequestDto: CreateGroupRequestDto): Promise<number> {
+    // 랜덤 코드 생성해서 그룹 생성
+    const { userId, groupImage, groupName } = createGroupRequestDto;
+    const groupCode = this.createInvitaionCode();
+
+    const user = await this.userRepository.findOne(userId, { relations: ["groups"] });
+    const group = await this.groupRepository.save({
+      groupImage: groupImage,
+      groupName: groupName,
+      groupCode: groupCode,
+    });
+    user.groups.push(group);
+    await this.userRepository.save(user);
+
+    return group.groupId;
+  }
+
+  createInvitaionCode(): string {
+    return "code";
+  }
+}

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -4,6 +4,7 @@ import { GroupRepository } from "../group.repository";
 import { CreateGroupRequestDto } from "src/dto/group/createGroupRequest.dto";
 import { UserRepository } from "src/user/user.repository";
 import { Group } from "../group.entity";
+import { AttendGroupRequestDto } from "src/dto/group/attendGroupRequest.dto";
 
 @Injectable()
 export class GroupService {
@@ -40,5 +41,17 @@ export class GroupService {
     } while (exists);
 
     return code;
+  }
+
+  async attendGroup(attendGroupRequestDto: AttendGroupRequestDto): Promise<number> {
+    const { userId, code } = attendGroupRequestDto;
+
+    const group = await this.groupRepository.findOne({ groupCode: code });
+    const user = await this.userRepository.findOne(userId, { relations: ["groups"] });
+
+    user.groups.push(group);
+    await this.userRepository.save(user);
+
+    return group.groupId;
   }
 }

--- a/backend/src/myBaseEntity/timestampEntity.ts
+++ b/backend/src/myBaseEntity/timestampEntity.ts
@@ -1,6 +1,6 @@
 import { BaseEntity, CreateDateColumn, DeleteDateColumn, UpdateDateColumn } from "typeorm";
 
-export class TimeStampEntity extends BaseEntity {
+export abstract class TimeStampEntity extends BaseEntity {
   @CreateDateColumn()
   createdAt: Date;
 

--- a/backend/src/myBaseEntity/timestampEntity.ts
+++ b/backend/src/myBaseEntity/timestampEntity.ts
@@ -1,0 +1,12 @@
+import { BaseEntity, CreateDateColumn, DeleteDateColumn, UpdateDateColumn } from "typeorm";
+
+export class TimeStampEntity extends BaseEntity {
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updateAt: Date;
+
+  @DeleteDateColumn()
+  deletedAt: Date;
+}

--- a/backend/src/user/controller/user.controller.ts
+++ b/backend/src/user/controller/user.controller.ts
@@ -10,13 +10,13 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Get("/:userId")
-  getUserInfo(@Param("userId") userId: number): Promise<UserInfoResponseDto> {
+  GetUserInfo(@Param("userId") userId: number): Promise<UserInfoResponseDto> {
     return this.userService.findUserInfo(userId);
   }
 
   @Put()
   @HttpCode(200)
-  updateUserInfo(@Body() updateUserInfoRequestDto: UpdateUserInfoRequestDto): Promise<string> {
+  UpdateUserInfo(@Body() updateUserInfoRequestDto: UpdateUserInfoRequestDto): Promise<string> {
     return this.userService.updateUserInfo(updateUserInfoRequestDto);
   }
 }

--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { RegisterUserDto } from "src/dto/user/register-user.dto";
+import { UserInfoDto } from "src/dto/user/userInfo.dto";
 import { User } from "../user.entity";
 import { UserRepository } from "../user.repository";
 import { UserInfoResponseDto } from "src/dto/user/userInfoResponse.dto";
@@ -13,7 +13,7 @@ export class UserService {
     private userRepository: UserRepository,
   ) {}
 
-  async registeredUser(registerUserDto: RegisterUserDto): Promise<User | undefined> {
+  async registeredUser(registerUserDto: UserInfoDto): Promise<User | undefined> {
     const userEmail = registerUserDto.userEmail;
 
     let user = await this.userRepository.findOne({ userEmail });

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -1,5 +1,6 @@
-import { Entity, Column, PrimaryGeneratedColumn } from "typeorm";
+import { Entity, Column, PrimaryGeneratedColumn, ManyToMany, JoinTable } from "typeorm";
 import { TimeStampEntity } from "src/myBaseEntity/TimestampEntity";
+import { Group } from "src/group/group.entity";
 
 @Entity({ name: "users" })
 export class User extends TimeStampEntity {
@@ -14,4 +15,8 @@ export class User extends TimeStampEntity {
 
   @Column()
   userEmail: string;
+
+  @ManyToMany(() => Group)
+  @JoinTable({ name: "users_groups_TB" })
+  groups: Group[];
 }

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -1,6 +1,6 @@
 import { Entity, Column, PrimaryGeneratedColumn, BaseEntity } from "typeorm";
 
-@Entity()
+@Entity({ name: "users" })
 export class User extends BaseEntity {
   @PrimaryGeneratedColumn()
   userId: number;

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -1,7 +1,8 @@
-import { Entity, Column, PrimaryGeneratedColumn, BaseEntity } from "typeorm";
+import { Entity, Column, PrimaryGeneratedColumn } from "typeorm";
+import { TimeStampEntity } from "src/myBaseEntity/TimestampEntity";
 
 @Entity({ name: "users" })
-export class User extends BaseEntity {
+export class User extends TimeStampEntity {
   @PrimaryGeneratedColumn()
   userId: number;
 

--- a/backend/src/user/user.repository.ts
+++ b/backend/src/user/user.repository.ts
@@ -1,10 +1,10 @@
-import { RegisterUserDto } from "src/dto/user/register-user.dto";
+import { UserInfoDto } from "src/dto/user/userInfo.dto";
 import { EntityRepository, Repository } from "typeorm";
 import { User } from "./user.entity";
 
 @EntityRepository(User)
 export class UserRepository extends Repository<User> {
-  async saveUser(registerUserDto: RegisterUserDto): Promise<User> {
+  async saveUser(registerUserDto: UserInfoDto): Promise<User> {
     const user = this.create(registerUserDto);
 
     return await this.save(user);


### PR DESCRIPTION
## 작업 내용
1. 그룹 생성 API
  - Body
    - 필수 : userId, groupName
    - 선택 : groupImage
  - Response
    - 200 Status, groupId
2. 그룹 참가 API
  - Body
    - 필수 : userId, code
  - Response
    - 200 Status, groupId
3. 그룹 정보 조회 API
  - Param
    - 필수 : groupId
  - Response
    - groupCode, users(profileImage, userNickname, userEmail)
    - users는 배열
    
## 고민한 부분
- Entity 생성시 매번 TimeStamp를 찍어주는 일이 반복될 것 같아서 따로 TimeStampEntity를 만들고 모든 Entity가 TimeStampEntity를 상속하여 사용하게 변경
  - TimeStamp Entity는 기존 Entity들이 상속받고 있던 BaseEntity를 상속받고 있음
  - 기존 : Entity -> 상속 -> BaseEntity
  - 변경 : Entity -> 상속 -> TimeStampEntity -> 상속 -> BaseEntity
- ManyToMany 부분을 이해하고 사용하는데 시간이 오래 걸렸다.

## 리뷰 포인트
그룹 정보 조회하는 부분에서 (`group.service.ts`) user 데이터의 전체 컬럼을 전부 가져오는 것이 아닌 TypeOrm의 Query Builder를 사용해서 원하는 컬럼만(image, nickname, email) 가져오게 끔 구현

## 관련된 이슈 넘버
#87 #83 #82 