### PR TITLE
그룹 정보 수정 및 탈퇴 API 구현

### DIFF
--- a/backend/src/dto/group/groupInfo.ts
+++ b/backend/src/dto/group/groupInfo.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString, IsOptional } from "class-validator";
+
+export class GroupInfo {
+  @IsString()
+  @IsOptional()
+  groupImage: string;
+
+  @IsString()
+  @IsNotEmpty()
+  groupName: string;
+}

--- a/backend/src/dto/group/leaveGroupRequest.dto.ts
+++ b/backend/src/dto/group/leaveGroupRequest.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsNumber } from "class-validator";
+
+export class LeaveGroupDto {
+  @IsNumber()
+  @IsNotEmpty()
+  userId: number;
+}

--- a/backend/src/dto/group/updateGroupInfoRequest.dto.ts
+++ b/backend/src/dto/group/updateGroupInfoRequest.dto.ts
@@ -1,8 +1,8 @@
 import { IsNotEmpty, IsNumber } from "class-validator";
 import { GroupInfo } from "./groupInfo";
 
-export class CreateGroupRequestDto extends GroupInfo {
+export class UpdateGroupInfoRequestDto extends GroupInfo {
   @IsNumber()
   @IsNotEmpty()
-  userId: number;
+  groupId: number;
 }

--- a/backend/src/dto/group/updateGroupInfoRequest.dto.ts
+++ b/backend/src/dto/group/updateGroupInfoRequest.dto.ts
@@ -1,8 +1,3 @@
-import { IsNotEmpty, IsNumber } from "class-validator";
 import { GroupInfo } from "./groupInfo";
 
-export class UpdateGroupInfoRequestDto extends GroupInfo {
-  @IsNumber()
-  @IsNotEmpty()
-  groupId: number;
-}
+export class UpdateGroupInfoRequestDto extends GroupInfo {}

--- a/backend/src/dto/user/updateUserInfoRequest.dto.ts
+++ b/backend/src/dto/user/updateUserInfoRequest.dto.ts
@@ -1,8 +1,3 @@
-import { IsNotEmpty, IsNumber } from "class-validator";
 import { UserInfoResponseDto } from "./userInfoResponse.dto";
 
-export class UpdateUserInfoRequestDto extends UserInfoResponseDto {
-  @IsNumber()
-  @IsNotEmpty()
-  userId: number;
-}
+export class UpdateUserInfoRequestDto extends UserInfoResponseDto {}

--- a/backend/src/group/controller/group.controller.ts
+++ b/backend/src/group/controller/group.controller.ts
@@ -38,8 +38,8 @@ export class GroupController {
     return this.groupService.updateGroupInfo(groupId, updateGroupInfoRequestDto);
   }
 
-  // @Delete()
-  // LeaveGroup(@Body() leaveGroupDto: LeaveGroupDto): Promise<string> {
-  //   return this.groupService.leaveGroup(leaveGroupDto);
-  // }
+  @Delete("/:groupId")
+  LeaveGroup(@Param("groupId") groupId: number, @Body() leaveGroupDto: LeaveGroupDto): Promise<string> {
+    return this.groupService.leaveGroup(groupId, leaveGroupDto);
+  }
 }

--- a/backend/src/group/controller/group.controller.ts
+++ b/backend/src/group/controller/group.controller.ts
@@ -1,10 +1,11 @@
-import { Body, Controller, Get, HttpCode, Param, Post, Put, UseGuards } from "@nestjs/common";
+import { Body, Controller, Get, HttpCode, Param, Post, Put, Delete, UseGuards } from "@nestjs/common";
 import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
 import { GroupService } from "../service/group.service";
 import { CreateGroupRequestDto } from "src/dto/group/createGroupRequest.dto";
 import { AttendGroupRequestDto } from "src/dto/group/attendGroupRequest.dto";
 import { GetGroupInfoResponseDto } from "src/dto/group/getGroupInfoResponse.dto";
 import { UpdateGroupInfoRequestDto } from "src/dto/group/updateGroupInfoRequest.dto";
+import { LeaveGroupDto } from "src/dto/group/leaveGroupRequest.dto";
 
 @UseGuards(JwtAuthGuard)
 @Controller("api/groups")
@@ -28,9 +29,17 @@ export class GroupController {
     return this.groupService.getGroupInfo(groupId);
   }
 
-  @Put()
+  @Put("/:groupId")
   @HttpCode(200)
-  UpdateGroupInfo(@Body() updateGroupInfoRequestDto: UpdateGroupInfoRequestDto): Promise<string> {
-    return this.groupService.updateGroupInfo(updateGroupInfoRequestDto);
+  UpdateGroupInfo(
+    @Param("groupId") groupId: number,
+    @Body() updateGroupInfoRequestDto: UpdateGroupInfoRequestDto,
+  ): Promise<string> {
+    return this.groupService.updateGroupInfo(groupId, updateGroupInfoRequestDto);
   }
+
+  // @Delete()
+  // LeaveGroup(@Body() leaveGroupDto: LeaveGroupDto): Promise<string> {
+  //   return this.groupService.leaveGroup(leaveGroupDto);
+  // }
 }

--- a/backend/src/group/controller/group.controller.ts
+++ b/backend/src/group/controller/group.controller.ts
@@ -1,9 +1,10 @@
-import { Body, Controller, Get, HttpCode, Param, Post, UseGuards } from "@nestjs/common";
+import { Body, Controller, Get, HttpCode, Param, Post, Put, UseGuards } from "@nestjs/common";
 import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
 import { GroupService } from "../service/group.service";
 import { CreateGroupRequestDto } from "src/dto/group/createGroupRequest.dto";
 import { AttendGroupRequestDto } from "src/dto/group/attendGroupRequest.dto";
 import { GetGroupInfoResponseDto } from "src/dto/group/getGroupInfoResponse.dto";
+import { UpdateGroupInfoRequestDto } from "src/dto/group/updateGroupInfoRequest.dto";
 
 @UseGuards(JwtAuthGuard)
 @Controller("api/groups")
@@ -25,5 +26,11 @@ export class GroupController {
   @Get("/:groupId")
   GetGroupInfo(@Param("groupId") groupId: number): Promise<GetGroupInfoResponseDto> {
     return this.groupService.getGroupInfo(groupId);
+  }
+
+  @Put()
+  @HttpCode(200)
+  UpdateGroupInfo(@Body() updateGroupInfoRequestDto: UpdateGroupInfoRequestDto): Promise<string> {
+    return this.groupService.updateGroupInfo(updateGroupInfoRequestDto);
   }
 }

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -8,6 +8,7 @@ import { AttendGroupRequestDto } from "src/dto/group/attendGroupRequest.dto";
 import { GetGroupInfoResponseDto } from "src/dto/group/getGroupInfoResponse.dto";
 import { UpdateGroupInfoRequestDto } from "src/dto/group/updateGroupInfoRequest.dto";
 import { LeaveGroupDto } from "src/dto/group/leaveGroupRequest.dto";
+import { DeleteResult } from "typeorm";
 
 @Injectable()
 export class GroupService {
@@ -59,13 +60,7 @@ export class GroupService {
   }
 
   async getGroupInfo(groupId: number): Promise<GetGroupInfoResponseDto> {
-    const group = await this.groupRepository
-      .createQueryBuilder("group")
-      .leftJoin("group.users", "user")
-      .select(["group.groupCode", "user.profileImage", "user.userNickname", "user.userEmail"])
-      .where("group.groupId = :id", { id: groupId })
-      .getOne();
-
+    const group = await this.readGroupQuery(groupId);
     if (!group) throw new NotFoundException("Not found group with the id " + groupId);
 
     const { groupCode, users } = group;
@@ -74,8 +69,8 @@ export class GroupService {
 
   async updateGroupInfo(groupId: number, updateGroupInfoRequestDto: UpdateGroupInfoRequestDto): Promise<string> {
     const { groupImage, groupName } = updateGroupInfoRequestDto;
-    const group = await this.groupRepository.findOne({ groupId });
 
+    const group = await this.groupRepository.findOne({ groupId });
     if (!group) throw new NotFoundException("Can not find Group");
 
     group.groupImage = groupImage;
@@ -88,15 +83,32 @@ export class GroupService {
   async leaveGroup(groupId: number, leaveGroupDto: LeaveGroupDto): Promise<string> {
     const { userId } = leaveGroupDto;
 
-    const result = await this.groupRepository
+    const result = await this.leaveGroupQuery(groupId, userId);
+    if (!result.affected) throw new NotFoundException("그룹에 해당 유저가 없습니다.");
+
+    const group = await this.readGroupQuery(groupId);
+    const { users } = group;
+
+    if (!users.length) await this.groupRepository.softDelete({ groupId });
+
+    return "Group leave success!!";
+  }
+
+  async readGroupQuery(groupId: number): Promise<Group> {
+    return await this.groupRepository
+      .createQueryBuilder("group")
+      .leftJoin("group.users", "user")
+      .select(["group.groupCode", "user.profileImage", "user.userNickname", "user.userEmail"])
+      .where("group.groupId = :id", { id: groupId })
+      .getOne();
+  }
+
+  async leaveGroupQuery(groupId: number, userId: number): Promise<DeleteResult> {
+    return await this.groupRepository
       .createQueryBuilder()
       .delete()
       .from("users_groups_TB")
       .where("groups_tb_group_id = :groupId AND users_user_id = :userId", { groupId: groupId, userId: userId })
       .execute();
-
-    if (!result.affected) throw new NotFoundException("그룹에 해당 유저가 없습니다.");
-
-    return "Group leave success!!";
   }
 }

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -6,6 +6,7 @@ import { Group } from "../group.entity";
 import { CreateGroupRequestDto } from "src/dto/group/createGroupRequest.dto";
 import { AttendGroupRequestDto } from "src/dto/group/attendGroupRequest.dto";
 import { GetGroupInfoResponseDto } from "src/dto/group/getGroupInfoResponse.dto";
+import { UpdateGroupInfoRequestDto } from "src/dto/group/updateGroupInfoRequest.dto";
 
 @Injectable()
 export class GroupService {
@@ -68,5 +69,18 @@ export class GroupService {
 
     const { groupCode, users } = group;
     return { groupCode, users };
+  }
+
+  async updateGroupInfo(updateGroupInfoRequestDto: UpdateGroupInfoRequestDto): Promise<string> {
+    const { groupId, groupImage, groupName } = updateGroupInfoRequestDto;
+    const group = await this.groupRepository.findOne({ groupId });
+
+    if (!group) throw new NotFoundException("Can not find Group");
+
+    group.groupImage = groupImage;
+    group.groupName = groupName;
+    await this.groupRepository.save(group);
+
+    return "GroupInfo update success!!";
   }
 }

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -7,6 +7,7 @@ import { CreateGroupRequestDto } from "src/dto/group/createGroupRequest.dto";
 import { AttendGroupRequestDto } from "src/dto/group/attendGroupRequest.dto";
 import { GetGroupInfoResponseDto } from "src/dto/group/getGroupInfoResponse.dto";
 import { UpdateGroupInfoRequestDto } from "src/dto/group/updateGroupInfoRequest.dto";
+import { LeaveGroupDto } from "src/dto/group/leaveGroupRequest.dto";
 
 @Injectable()
 export class GroupService {
@@ -82,5 +83,20 @@ export class GroupService {
     await this.groupRepository.save(group);
 
     return "GroupInfo update success!!";
+  }
+
+  async leaveGroup(groupId: number, leaveGroupDto: LeaveGroupDto): Promise<string> {
+    const { userId } = leaveGroupDto;
+
+    const result = await this.groupRepository
+      .createQueryBuilder()
+      .delete()
+      .from("users_groups_TB")
+      .where("groups_tb_group_id = :groupId AND users_user_id = :userId", { groupId: groupId, userId: userId })
+      .execute();
+
+    if (!result.affected) throw new NotFoundException("그룹에 해당 유저가 없습니다.");
+
+    return "Group leave success!!";
   }
 }

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -71,8 +71,8 @@ export class GroupService {
     return { groupCode, users };
   }
 
-  async updateGroupInfo(updateGroupInfoRequestDto: UpdateGroupInfoRequestDto): Promise<string> {
-    const { groupId, groupImage, groupName } = updateGroupInfoRequestDto;
+  async updateGroupInfo(groupId: number, updateGroupInfoRequestDto: UpdateGroupInfoRequestDto): Promise<string> {
+    const { groupImage, groupName } = updateGroupInfoRequestDto;
     const group = await this.groupRepository.findOne({ groupId });
 
     if (!group) throw new NotFoundException("Can not find Group");

--- a/backend/src/user/controller/user.controller.ts
+++ b/backend/src/user/controller/user.controller.ts
@@ -11,7 +11,7 @@ export class UserController {
 
   @Get("/:userId")
   GetUserInfo(@Param("userId") userId: number): Promise<UserInfoResponseDto> {
-    return this.userService.findUserInfo(userId);
+    return this.userService.getUserInfo(userId);
   }
 
   @Put()

--- a/backend/src/user/controller/user.controller.ts
+++ b/backend/src/user/controller/user.controller.ts
@@ -14,9 +14,12 @@ export class UserController {
     return this.userService.getUserInfo(userId);
   }
 
-  @Put()
+  @Put("/:userId")
   @HttpCode(200)
-  UpdateUserInfo(@Body() updateUserInfoRequestDto: UpdateUserInfoRequestDto): Promise<string> {
-    return this.userService.updateUserInfo(updateUserInfoRequestDto);
+  UpdateUserInfo(
+    @Param("userId") userId: number,
+    @Body() updateUserInfoRequestDto: UpdateUserInfoRequestDto,
+  ): Promise<string> {
+    return this.userService.updateUserInfo(userId, updateUserInfoRequestDto);
   }
 }

--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -22,7 +22,7 @@ export class UserService {
     return user;
   }
 
-  async findUserInfo(userId: number): Promise<UserInfoResponseDto> {
+  async getUserInfo(userId: number): Promise<UserInfoResponseDto> {
     const user = await this.userRepository.findOne({ userId });
 
     if (!user) throw new NotFoundException("Can not find User");

--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -31,8 +31,8 @@ export class UserService {
     return { profileImage, userNickname };
   }
 
-  async updateUserInfo(updateUserInfoRequestDto: UpdateUserInfoRequestDto): Promise<string> {
-    const { userId, profileImage, userNickname } = updateUserInfoRequestDto;
+  async updateUserInfo(userId: number, updateUserInfoRequestDto: UpdateUserInfoRequestDto): Promise<string> {
+    const { profileImage, userNickname } = updateUserInfoRequestDto;
     const user = await this.userRepository.findOne({ userId });
 
     if (!user) throw new NotFoundException("Can not find User");


### PR DESCRIPTION
## 작업 내용
- 그룹 정보 수정 API
  - Param : groupId
  - Body : groupImage, groupName(필수)
  - Response : Status Code(200 or 404)
- 그룹 탈퇴 API
  - Param : groupId
  - Body : userId(필수)
  - Response : Status Code(200 or 404)
  - 특징 : 그룹에 그룹원이 하나도 없을 시 그룹도 같이 삭제


## 고민한 부분
- 그룹원이 하나도 없을 시 그룹을 삭제해줘야하는데 이 때, 쿼리를 사용해 DB를 한 번 더 조회하는 방법 밖에 없는지 고민...
  - 일단은 따로 생각이 나지 않아서 이렇게 구현했습니다.
- 삭제시 softDelete를 진행해야해서 typeOrm이 지원해주는 softDelete를 사용했습니다.

## 리뷰 포인트
DB 쿼리문 작성한거 잘 작성했는지 모르겠습니당..ㅠㅠ

## 관련된 이슈 넘버
#88 #89 