### PR TITLE
해시태그 추천 구현

### DIFF
--- a/frontend/src/components/Header/Profile/Search/Recommend/index.tsx
+++ b/frontend/src/components/Header/Profile/Search/Recommend/index.tsx
@@ -1,0 +1,98 @@
+import { Dispatch, MouseEventHandler, ReactEventHandler, SetStateAction } from "react";
+import COLOR from "@src/styles/Color";
+import styled from "styled-components";
+
+interface RecommendProps {
+  inputKeyword: string;
+  setSearchKeyword: Dispatch<SetStateAction<string>>;
+  doSearch: Function;
+}
+interface TagType {
+  id: number;
+  name: string;
+}
+
+const Recommend = ({ inputKeyword, setSearchKeyword, doSearch }: RecommendProps) => {
+  const allTagList = [
+    { id: 0, name: "미삼집" },
+    { id: 1, name: "맥도날드" },
+    { id: 2, name: "농성화로" },
+    { id: 3, name: "아웃백" },
+    { id: 4, name: "버거킹" },
+    { id: 5, name: "롯데리아" },
+    { id: 6, name: "kfc" },
+    { id: 7, name: "포도주" },
+    { id: 8, name: "솥뚜껑" },
+    { id: 9, name: "팔팔소곱창" },
+    { id: 10, name: "청해" },
+    { id: 11, name: "맥도널드" },
+    { id: 12, name: "청헤" },
+  ];
+
+  const recommendTag = (tagList: TagType[], input: string) => {
+    const recommendArray = tagList.filter((tag) => tag.name.indexOf(input) !== -1);
+    return recommendArray;
+  };
+
+  const recommendArray = recommendTag(allTagList, inputKeyword);
+
+  const onClickHashTag = (e: React.MouseEvent<HTMLSpanElement>) => {
+    const selectedTag = (e.target as HTMLElement).innerHTML;
+    setSearchKeyword(selectedTag);
+    doSearch(selectedTag);
+  };
+
+  return (
+    <SearchListContainer>
+      {recommendArray.length > 0 ? (
+        <>
+          <ul>
+            {recommendArray.map(({ id, name }) => (
+              <li key={id}>
+                #<span onClick={onClickHashTag}>{name}</span>
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+    </SearchListContainer>
+  );
+};
+
+const SearchListContainer = styled.div`
+  position: absolute;
+  background-color: ${COLOR.WHITE};
+  border-radius: 5px;
+  top: 5.5vh;
+  z-index: 6;
+  width: 25vw;
+  box-sizing: border-box;
+  overflow-y: scroll;
+  max-height: 20vh;
+  &::-webkit-scrollbar {
+    width: 0.6vw;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: ${COLOR.LIGHTGRAY2};
+    border-radius: 5px;
+  }
+  & ul {
+    margin: 0.5vw;
+    & li {
+      float: left;
+      margin: 8px;
+
+      background-color: ${(props) => props.theme.SECONDARY};
+      border-radius: 20px;
+      padding: 0.4vw;
+      color: ${COLOR.WHITE};
+      font-size: 0.8rem;
+      &:hover {
+        background-color: ${(props) => props.theme.PRIMARY};
+        cursor: pointer;
+      }
+    }
+  }
+`;
+
+export default Recommend;

--- a/frontend/src/components/Header/Profile/Search/SearchList/index.tsx
+++ b/frontend/src/components/Header/Profile/Search/SearchList/index.tsx
@@ -49,7 +49,6 @@ const SearchList = ({ setSearchKeyword, setIsSearchListOpened }: SearchListProps
     </SearchListContainer>
   );
 };
-
 const SearchListContainer = styled.div`
   position: absolute;
   background-color: ${COLOR.WHITE};
@@ -58,16 +57,17 @@ const SearchListContainer = styled.div`
   z-index: 6;
   width: 25vw;
   font-size: 1rem;
+  box-sizing: border-box;
+  overflow-y: scroll;
+  &::-webkit-scrollbar {
+    width: 0.6vw;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: ${COLOR.LIGHTGRAY2};
+    border-radius: 5px;
+  }
   & ul {
-    height: 20vh;
-    overflow-y: scroll;
-    &::-webkit-scrollbar {
-      width: 1vw;
-    }
-    &::-webkit-scrollbar-thumb {
-      background-color: ${COLOR.LIGHTGRAY2};
-      border-radius: 5px;
-    }
+    max-height: 20vh;
     margin: 1.5vw 0 1.5vw 1.5vw;
     & li {
       padding: 1vh 0 1vh 1vh;
@@ -82,8 +82,7 @@ const SearchListContainer = styled.div`
         padding-top: 0;
       }
       &:nth-last-child(1) {
-        border-bottom: none;
-        padding-bottom: 0;
+        padding-bottom: 1.2vh;
       }
     }
   }

--- a/frontend/src/components/Header/Profile/Search/SearchList/index.tsx
+++ b/frontend/src/components/Header/Profile/Search/SearchList/index.tsx
@@ -14,17 +14,17 @@ interface SearchListProps {
 
 const SearchList = ({ setSearchKeyword, setIsSearchListOpened }: SearchListProps) => {
   const searchListContents: SearchListContent[] = [
-    { id: 0, name: "미삼집" },
-    { id: 1, name: "맥도날드" },
-    { id: 2, name: "농성화로" },
-    { id: 3, name: "아웃백" },
-    { id: 4, name: "버거킹" },
-    { id: 5, name: "롯데리아" },
-    { id: 6, name: "kfc" },
-    { id: 7, name: "포도주" },
-    { id: 8, name: "솥뚜껑" },
-    { id: 9, name: "팔팔소곱창" },
-    { id: 10, name: "청해" },
+    { id: 0, name: "미삼집 관련 게시글" },
+    { id: 1, name: "맥도날드 관련 게시글" },
+    { id: 2, name: "농성화로 관련 게시글" },
+    { id: 3, name: "아웃백 관련 게시글" },
+    { id: 4, name: "버거킹 관련 게시글" },
+    { id: 5, name: "롯데리아 관련 게시글" },
+    { id: 6, name: "kfc 관련 게시글" },
+    { id: 7, name: "포도주 관련 게시글" },
+    { id: 8, name: "솥뚜껑 관련 게시글" },
+    { id: 9, name: "팔팔소곱창 관련 게시글" },
+    { id: 10, name: "청해 관련 게시글" },
   ];
 
   const handleClickSearchListItem = (e: HTMLElement) => {

--- a/frontend/src/components/Header/Profile/Search/index.tsx
+++ b/frontend/src/components/Header/Profile/Search/index.tsx
@@ -70,7 +70,8 @@ const SearchContainer = styled.div`
 `;
 
 const SearchInput = styled.input`
-  height: 90%;
+  height: 100%;
+  width: 80%;
   border: none;
   &:focus-visible {
     outline: none;

--- a/frontend/src/components/Header/Profile/Search/index.tsx
+++ b/frontend/src/components/Header/Profile/Search/index.tsx
@@ -15,17 +15,24 @@ const Search = () => {
   const handleKeyPress = (e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "Enter" && searchKeyword) {
       setIsSearchListOpened(true);
+    } else {
+      setIsSearchListOpened(false);
     }
+  };
+
+  const onClickBackGround = () => {
+    setIsSearchListOpened(false);
   };
 
   return (
     <>
+      {isSearchListOpened && <BackGround onClick={onClickBackGround} />}
       <SearchContainer>
         <img src="/icons/search.svg" height="90%" alt="search" />
         <SearchInput
           type="text"
           placeholder="해시태그를 입력하세요."
-          onKeyPress={handleKeyPress}
+          onKeyUp={handleKeyPress}
           onChange={handleSearchInputChange}
           value={searchKeyword}
         />
@@ -37,6 +44,16 @@ const Search = () => {
   );
 };
 
+const BackGround = styled.div`
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  width: 100%;
+  height: 100%;
+  background-color: transparent;
+  z-index: 3;
+`;
+
 const SearchContainer = styled.div`
   display: flex;
   justify-content: flex-start;
@@ -46,6 +63,7 @@ const SearchContainer = styled.div`
   background-color: ${COLOR.WHITE};
   border-radius: 5px;
   padding: 0.5vh 0;
+  z-index: 6;
   & > img {
     padding: 0 0.5vw;
   }

--- a/frontend/src/components/Header/Profile/Search/index.tsx
+++ b/frontend/src/components/Header/Profile/Search/index.tsx
@@ -3,10 +3,12 @@ import COLOR from "@styles/Color";
 import styled from "styled-components";
 
 import SearchList from "@components/Header/Profile/Search/SearchList";
+import Recommend from "@components/Header/Profile/Search/Recommend";
 
 const Search = () => {
   const [searchKeyword, setSearchKeyword] = useState<string>("");
   const [isSearchListOpened, setIsSearchListOpened] = useState<Boolean>(false);
+  const [isRecommendOpened, setIsRecommendOpened] = useState<Boolean>(false);
 
   const handleSearchInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchKeyword(e.target.value);
@@ -14,19 +16,29 @@ const Search = () => {
 
   const handleKeyPress = (e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "Enter" && searchKeyword) {
-      setIsSearchListOpened(true);
-    } else {
-      setIsSearchListOpened(false);
+      (document.activeElement as HTMLElement).blur();
+      doSearch(searchKeyword);
     }
+  };
+
+  const doSearch = (key: string) => {
+    setIsSearchListOpened(true);
+    setIsRecommendOpened(false);
+  };
+
+  const onFocusInput = () => {
+    setIsRecommendOpened(true);
+    setIsSearchListOpened(false);
   };
 
   const onClickBackGround = () => {
     setIsSearchListOpened(false);
+    setIsRecommendOpened(false);
   };
 
   return (
     <>
-      {isSearchListOpened && <BackGround onClick={onClickBackGround} />}
+      {(isSearchListOpened || isRecommendOpened) && <BackGround onClick={onClickBackGround} />}
       <SearchContainer>
         <img src="/icons/search.svg" height="90%" alt="search" />
         <SearchInput
@@ -35,9 +47,13 @@ const Search = () => {
           onKeyUp={handleKeyPress}
           onChange={handleSearchInputChange}
           value={searchKeyword}
+          onFocus={onFocusInput}
         />
         {isSearchListOpened && (
           <SearchList setSearchKeyword={setSearchKeyword} setIsSearchListOpened={setIsSearchListOpened} />
+        )}
+        {isRecommendOpened && (
+          <Recommend setSearchKeyword={setSearchKeyword} inputKeyword={searchKeyword} doSearch={doSearch} />
         )}
       </SearchContainer>
     </>

--- a/frontend/src/components/Sidebar/FirstDepth/Group/index.tsx
+++ b/frontend/src/components/Sidebar/FirstDepth/Group/index.tsx
@@ -57,6 +57,7 @@ const Group = ({ setIsToggle, groupID, groupName, groupImg, DragHandler, DragEnd
       onDrag={DragHandler}
       onDragEnd={DragEndHandler}
       onClick={onClickGroup}
+      onDragOver={(e) => e.preventDefault()}
     ></ButtonWrapper>
   );
 };

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Album/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Album/index.tsx
@@ -34,7 +34,7 @@ const Album = ({
   const [postToggle, setPostToggle] = useState(true);
 
   return (
-    <div onDrop={DropHandler} onDragLeave={DragLeaveHandler}>
+    <div onDrop={DropHandler} onDragLeave={DragLeaveHandler} onDragOver={(e) => e.preventDefault()}>
       <Header
         albumID={album.albumID}
         albumName={album.albumName}

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Post/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Post/index.tsx
@@ -36,6 +36,7 @@ const Post = ({
       onDragEnd={PostDragEndHandler}
       data-id={idx}
       data-albumidx={albumIdx}
+      onDragOver={(e) => e.preventDefault()}
     >
       {postTitle}
     </PostWrapper>


### PR DESCRIPTION
## 작업 내용
![해시태그추천](https://user-images.githubusercontent.com/34854154/141132763-01c6c6d0-9399-4d86-a852-807b94c1adeb.gif)
- 관련된 해시태그를 추천해 준다
    - 키 입력 이벤트 발생 시 가지고 있는 해시태그 리스트 배열을 filter 돌면서 target value를 포함한 해시태그 리시트를 이용
- 해시태그 결과 모달 닫는 이벤트 추가
    - 모달 바깥 영역 click
    - input tag focus    
- Mac 사용자가 기본적으로 가지고 있는 드래그 애니메이션 방지 

## 고민한 부분
- 좋은 UI/UX를 위한 고민

## 리뷰 포인트
- 잘 부탁 드립니다

## 관련된 이슈 넘버
[#29, #101]