### PR TITLE
앨범 생성, 수정, 삭제 API 구현

### DIFF
--- a/backend/src/album/album.entity.ts
+++ b/backend/src/album/album.entity.ts
@@ -1,0 +1,16 @@
+import { Group } from "src/group/group.entity";
+import { TimeStampEntity } from "src/myBaseEntity/timestampEntity";
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity({ name: "albums" })
+export class Album extends TimeStampEntity {
+  @PrimaryGeneratedColumn()
+  albumId: number;
+
+  @Column()
+  albumName: string;
+
+  @ManyToOne(() => Group, group => group.albums)
+  @JoinColumn({ name: "group_id" })
+  group: Group;
+}

--- a/backend/src/album/album.entity.ts
+++ b/backend/src/album/album.entity.ts
@@ -10,7 +10,7 @@ export class Album extends TimeStampEntity {
   @Column()
   albumName: string;
 
-  @ManyToOne(() => Group, group => group.albums)
+  @ManyToOne(() => Group, group => group.albums, { onDelete: "CASCADE" })
   @JoinColumn({ name: "group_id" })
   group: Group;
 }

--- a/backend/src/album/album.entity.ts
+++ b/backend/src/album/album.entity.ts
@@ -1,6 +1,7 @@
 import { Group } from "src/group/group.entity";
 import { TimeStampEntity } from "src/myBaseEntity/timestampEntity";
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Post } from "src/post/post.entity";
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity({ name: "albums" })
 export class Album extends TimeStampEntity {
@@ -13,4 +14,7 @@ export class Album extends TimeStampEntity {
   @ManyToOne(() => Group, group => group.albums, { onDelete: "CASCADE" })
   @JoinColumn({ name: "group_id" })
   group: Group;
+
+  @OneToMany(() => Post, post => post.album)
+  posts: Post[];
 }

--- a/backend/src/album/album.module.ts
+++ b/backend/src/album/album.module.ts
@@ -4,10 +4,11 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { AlbumController } from "./controller/album.controller";
 import { AlbumService } from "./service/album.service";
 import { AlbumRepository } from "./album.repository";
+import { GroupRepository } from "src/group/group.repository";
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([AlbumRepository]),
+    TypeOrmModule.forFeature([AlbumRepository, GroupRepository]),
     JwtModule.register({
       secret: process.env.JWT_SECRET,
     }),

--- a/backend/src/album/album.module.ts
+++ b/backend/src/album/album.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { JwtModule } from "@nestjs/jwt";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { AlbumController } from "./controller/album.controller";
+import { AlbumService } from "./service/album.service";
+import { AlbumRepository } from "./album.repository";
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([AlbumRepository]),
+    JwtModule.register({
+      secret: process.env.JWT_SECRET,
+    }),
+  ],
+  controllers: [AlbumController],
+  providers: [AlbumService],
+})
+export class AlbumModule {}

--- a/backend/src/album/album.repository.ts
+++ b/backend/src/album/album.repository.ts
@@ -1,0 +1,5 @@
+import { EntityRepository, Repository } from "typeorm";
+import { Album } from "./album.entity";
+
+@EntityRepository(Album)
+export class AlbumRepository extends Repository<Album> {}

--- a/backend/src/album/controller/album.controller.spec.ts
+++ b/backend/src/album/controller/album.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { AlbumController } from "./album.controller";
+
+describe("AlbumController", () => {
+  let controller: AlbumController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AlbumController],
+    }).compile();
+
+    controller = module.get<AlbumController>(AlbumController);
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/album/controller/album.controller.ts
+++ b/backend/src/album/controller/album.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from "@nestjs/common";
+
+@Controller("album")
+export class AlbumController {}

--- a/backend/src/album/controller/album.controller.ts
+++ b/backend/src/album/controller/album.controller.ts
@@ -8,12 +8,9 @@ import { CreateAlbumRequestDto } from "src/dto/album/createAlbumRequest.dto";
 export class AlbumController {
   constructor(private readonly albumService: AlbumService) {}
 
-  @Post("/:groupId")
+  @Post()
   @HttpCode(200)
-  CreateAlbum(
-    @Param("groupId") groupId: number,
-    @Body() createAlbumRequestDto: CreateAlbumRequestDto,
-  ): Promise<number> {
-    return this.albumService.createAlbum(groupId, createAlbumRequestDto);
+  CreateAlbum(@Body() createAlbumRequestDto: CreateAlbumRequestDto): Promise<number> {
+    return this.albumService.createAlbum(createAlbumRequestDto);
   }
 }

--- a/backend/src/album/controller/album.controller.ts
+++ b/backend/src/album/controller/album.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, HttpCode, Param, Post, Put, UseGuards } from "@nestjs/common";
+import { Body, Controller, Delete, HttpCode, Param, Post, Put, UseGuards } from "@nestjs/common";
 import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
 import { AlbumService } from "../service/album.service";
 import { CreateAlbumRequestDto } from "src/dto/album/createAlbumRequest.dto";
@@ -22,5 +22,11 @@ export class AlbumController {
     @Body() updateAlbumInfoRequestDto: UpdateAlbumInfoRequestDto,
   ): Promise<string> {
     return this.albumService.updateAlbumInfo(albumId, updateAlbumInfoRequestDto);
+  }
+
+  @Delete("/:albumId")
+  @HttpCode(200)
+  DeleteAlbum(@Param("albumId") albumId: number): Promise<string> {
+    return this.albumService.deleteAlbum(albumId);
   }
 }

--- a/backend/src/album/controller/album.controller.ts
+++ b/backend/src/album/controller/album.controller.ts
@@ -1,4 +1,19 @@
-import { Controller } from "@nestjs/common";
+import { Body, Controller, HttpCode, Param, Post, UseGuards } from "@nestjs/common";
+import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
+import { AlbumService } from "../service/album.service";
+import { CreateAlbumRequestDto } from "src/dto/album/createAlbumRequest.dto";
 
-@Controller("album")
-export class AlbumController {}
+@UseGuards(JwtAuthGuard)
+@Controller("api/albums")
+export class AlbumController {
+  constructor(private readonly albumService: AlbumService) {}
+
+  @Post("/:groupId")
+  @HttpCode(200)
+  CreateAlbum(
+    @Param("groupId") groupId: number,
+    @Body() createAlbumRequestDto: CreateAlbumRequestDto,
+  ): Promise<number> {
+    return this.albumService.createAlbum(groupId, createAlbumRequestDto);
+  }
+}

--- a/backend/src/album/controller/album.controller.ts
+++ b/backend/src/album/controller/album.controller.ts
@@ -1,7 +1,8 @@
-import { Body, Controller, HttpCode, Post, UseGuards } from "@nestjs/common";
+import { Body, Controller, HttpCode, Param, Post, Put, UseGuards } from "@nestjs/common";
 import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
 import { AlbumService } from "../service/album.service";
 import { CreateAlbumRequestDto } from "src/dto/album/createAlbumRequest.dto";
+import { UpdateAlbumInfoRequestDto } from "src/dto/album/updateAlbumInfoRequest.dto";
 
 @UseGuards(JwtAuthGuard)
 @Controller("api/albums")
@@ -12,5 +13,14 @@ export class AlbumController {
   @HttpCode(200)
   CreateAlbum(@Body() createAlbumRequestDto: CreateAlbumRequestDto): Promise<string> {
     return this.albumService.createAlbum(createAlbumRequestDto);
+  }
+
+  @Put("/:albumId")
+  @HttpCode(200)
+  UpdateAlbumInfo(
+    @Param("albumId") albumId: number,
+    @Body() updateAlbumInfoRequestDto: UpdateAlbumInfoRequestDto,
+  ): Promise<string> {
+    return this.albumService.updateAlbumInfo(albumId, updateAlbumInfoRequestDto);
   }
 }

--- a/backend/src/album/controller/album.controller.ts
+++ b/backend/src/album/controller/album.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, HttpCode, Param, Post, UseGuards } from "@nestjs/common";
+import { Body, Controller, HttpCode, Post, UseGuards } from "@nestjs/common";
 import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
 import { AlbumService } from "../service/album.service";
 import { CreateAlbumRequestDto } from "src/dto/album/createAlbumRequest.dto";
@@ -10,7 +10,7 @@ export class AlbumController {
 
   @Post()
   @HttpCode(200)
-  CreateAlbum(@Body() createAlbumRequestDto: CreateAlbumRequestDto): Promise<number> {
+  CreateAlbum(@Body() createAlbumRequestDto: CreateAlbumRequestDto): Promise<string> {
     return this.albumService.createAlbum(createAlbumRequestDto);
   }
 }

--- a/backend/src/album/service/album.service.spec.ts
+++ b/backend/src/album/service/album.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { AlbumService } from "./album.service";
+
+describe("AlbumService", () => {
+  let service: AlbumService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AlbumService],
+    }).compile();
+
+    service = module.get<AlbumService>(AlbumService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class AlbumService {}

--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -1,4 +1,28 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { AlbumRepository } from "../album.repository";
+import { CreateAlbumRequestDto } from "src/dto/album/createAlbumRequest.dto";
+import { GroupRepository } from "src/group/group.repository";
 
 @Injectable()
-export class AlbumService {}
+export class AlbumService {
+  constructor(
+    @InjectRepository(AlbumRepository)
+    private albumRepository: AlbumRepository,
+    @InjectRepository(GroupRepository)
+    private groupRepository: GroupRepository,
+  ) {}
+
+  async createAlbum(groupId: number, createAlbumRequestDto: CreateAlbumRequestDto): Promise<number> {
+    const { albumName } = createAlbumRequestDto;
+    const group = await this.groupRepository.findOne({ groupId });
+    if (!group) throw new NotFoundException("Not found group with the id " + groupId);
+
+    const album = await this.albumRepository.save({
+      albumName: albumName,
+      group: group,
+    });
+
+    return album.albumId;
+  }
+}

--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -13,8 +13,8 @@ export class AlbumService {
     private groupRepository: GroupRepository,
   ) {}
 
-  async createAlbum(groupId: number, createAlbumRequestDto: CreateAlbumRequestDto): Promise<number> {
-    const { albumName } = createAlbumRequestDto;
+  async createAlbum(createAlbumRequestDto: CreateAlbumRequestDto): Promise<number> {
+    const { groupId, albumName } = createAlbumRequestDto;
     const group = await this.groupRepository.findOne({ groupId });
     if (!group) throw new NotFoundException("Not found group with the id " + groupId);
 

--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -17,7 +17,7 @@ export class AlbumService {
   async createAlbum(createAlbumRequestDto: CreateAlbumRequestDto): Promise<string> {
     const { groupId, albumName } = createAlbumRequestDto;
     const group = await this.groupRepository.findOne({ groupId });
-    if (!group) throw new NotFoundException("Not found group with the id " + groupId);
+    if (!group) throw new NotFoundException(`Not found group with the id ${groupId}`);
 
     const album = await this.albumRepository.save({
       albumName: albumName,

--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -13,7 +13,7 @@ export class AlbumService {
     private groupRepository: GroupRepository,
   ) {}
 
-  async createAlbum(createAlbumRequestDto: CreateAlbumRequestDto): Promise<number> {
+  async createAlbum(createAlbumRequestDto: CreateAlbumRequestDto): Promise<string> {
     const { groupId, albumName } = createAlbumRequestDto;
     const group = await this.groupRepository.findOne({ groupId });
     if (!group) throw new NotFoundException("Not found group with the id " + groupId);
@@ -23,6 +23,6 @@ export class AlbumService {
       group: group,
     });
 
-    return album.albumId;
+    return album.albumName;
   }
 }

--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -1,8 +1,9 @@
 import { Injectable, NotFoundException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { AlbumRepository } from "../album.repository";
-import { CreateAlbumRequestDto } from "src/dto/album/createAlbumRequest.dto";
 import { GroupRepository } from "src/group/group.repository";
+import { CreateAlbumRequestDto } from "src/dto/album/createAlbumRequest.dto";
+import { UpdateAlbumInfoRequestDto } from "src/dto/album/updateAlbumInfoRequest.dto";
 
 @Injectable()
 export class AlbumService {
@@ -24,5 +25,16 @@ export class AlbumService {
     });
 
     return album.albumName;
+  }
+
+  async updateAlbumInfo(albumId: number, updateAlbumInfoRequestDto: UpdateAlbumInfoRequestDto): Promise<string> {
+    const { albumName } = updateAlbumInfoRequestDto;
+    const album = await this.albumRepository.findOne({ albumId });
+    if (!album) throw new NotFoundException("Can not find Album");
+
+    album.albumName = albumName;
+    await this.albumRepository.save(album);
+
+    return "AlbumInfo update success!!";
   }
 }

--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -37,4 +37,13 @@ export class AlbumService {
 
     return "AlbumInfo update success!!";
   }
+
+  async deleteAlbum(albumId: number): Promise<string> {
+    const album = await this.albumRepository.findOne(albumId);
+    if (!album) throw new NotFoundException("Can not find Album");
+
+    await this.albumRepository.softDelete({ albumId });
+
+    return "Album delete success!!";
+  }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,8 +4,9 @@ import { typeORMConfig } from "./configs/typeorm.config";
 import { UserModule } from "./user/user.module";
 import { AuthModule } from "./auth/auth.module";
 import { GroupModule } from "./group/group.module";
+import { AlbumModule } from "./album/album.module";
 
 @Module({
-  imports: [TypeOrmModule.forRoot(typeORMConfig), UserModule, AuthModule, GroupModule],
+  imports: [TypeOrmModule.forRoot(typeORMConfig), UserModule, AuthModule, GroupModule, AlbumModule],
 })
 export class AppModule {}

--- a/backend/src/dto/album/albumInfo.ts
+++ b/backend/src/dto/album/albumInfo.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class AlbumInfo {
+  @IsString()
+  @IsNotEmpty()
+  albumName: string;
+}

--- a/backend/src/dto/album/createAlbumRequest.dto.ts
+++ b/backend/src/dto/album/createAlbumRequest.dto.ts
@@ -1,11 +1,8 @@
-import { IsNotEmpty, IsNumber, IsString } from "class-validator";
+import { IsNotEmpty, IsNumber } from "class-validator";
+import { AlbumInfo } from "./albumInfo";
 
-export class CreateAlbumRequestDto {
+export class CreateAlbumRequestDto extends AlbumInfo {
   @IsNumber()
   @IsNotEmpty()
   groupId: number;
-
-  @IsString()
-  @IsNotEmpty()
-  albumName: string;
 }

--- a/backend/src/dto/album/createAlbumRequest.dto.ts
+++ b/backend/src/dto/album/createAlbumRequest.dto.ts
@@ -1,6 +1,10 @@
-import { IsNotEmpty, IsString } from "class-validator";
+import { IsNotEmpty, IsNumber, IsString } from "class-validator";
 
 export class CreateAlbumRequestDto {
+  @IsNumber()
+  @IsNotEmpty()
+  groupId: number;
+
   @IsString()
   @IsNotEmpty()
   albumName: string;

--- a/backend/src/dto/album/createAlbumRequest.dto.ts
+++ b/backend/src/dto/album/createAlbumRequest.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class CreateAlbumRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  albumName: string;
+}

--- a/backend/src/dto/album/updateAlbumInfoRequest.dto.ts
+++ b/backend/src/dto/album/updateAlbumInfoRequest.dto.ts
@@ -1,0 +1,3 @@
+import { AlbumInfo } from "./albumInfo";
+
+export class UpdateAlbumInfoRequestDto extends AlbumInfo {}

--- a/backend/src/group/group.entity.ts
+++ b/backend/src/group/group.entity.ts
@@ -1,6 +1,7 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToMany, JoinTable } from "typeorm";
+import { Entity, PrimaryGeneratedColumn, Column, ManyToMany, JoinTable, OneToMany } from "typeorm";
 import { TimeStampEntity } from "src/myBaseEntity/timestampEntity";
 import { User } from "src/user/user.entity";
+import { Album } from "src/album/album.entity";
 
 @Entity({ name: "groups_TB" })
 export class Group extends TimeStampEntity {
@@ -19,4 +20,7 @@ export class Group extends TimeStampEntity {
   @ManyToMany(() => User)
   @JoinTable({ name: "users_groups_TB" })
   users: User[];
+
+  @OneToMany(() => Album, Album => Album.group)
+  albums: Album[];
 }

--- a/backend/src/group/group.entity.ts
+++ b/backend/src/group/group.entity.ts
@@ -21,6 +21,6 @@ export class Group extends TimeStampEntity {
   @JoinTable({ name: "users_groups_TB" })
   users: User[];
 
-  @OneToMany(() => Album, Album => Album.group)
+  @OneToMany(() => Album, album => album.group)
   albums: Album[];
 }

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -64,7 +64,7 @@ export class GroupService {
       .where("group.groupId = :id", { id: groupId })
       .getOne();
 
-    if (!group) throw new NotFoundException("Not found group with the id " + groupId);
+    if (!group) throw new NotFoundException(`Not found group with the id ${groupId}`);
 
     const { groupCode, users } = group;
     return { groupCode, users };

--- a/backend/src/post/post.entity.ts
+++ b/backend/src/post/post.entity.ts
@@ -1,0 +1,31 @@
+import { Album } from "src/album/album.entity";
+import { TimeStampEntity } from "src/myBaseEntity/timestampEntity";
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from "typeorm";
+
+@Entity({ name: "posts" })
+export class Post extends TimeStampEntity {
+  @PrimaryGeneratedColumn()
+  postId: number;
+
+  @Column()
+  postTitle: string;
+
+  @Column()
+  postContent: string;
+
+  @Column()
+  rememberDate: Date;
+
+  @Column()
+  postLocation: string;
+
+  @Column({ type: "decimal", precision: 18, scale: 10 })
+  postLatitude: number;
+
+  @Column({ type: "decimal", precision: 18, scale: 10 })
+  postLongitude: number;
+
+  @ManyToOne(() => Album, album => album.posts, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "album_id" })
+  album: Album;
+}


### PR DESCRIPTION
## 작업 내용
- 앨범 생성 API
  - Body
    - 필수 : groupId, albumName
  - Response
    - Status Code(200), 생성한 앨범명
- 앨범 수정 API
  - Param : albumId
  - Body
    - 필수 : albumName
  - Response
    - Status Code(200)
- 앨범 삭제 API
  - Param : albumId
  - Response
    - Status Code(200)
    - 특징 : 앨범 안에 존재하는 게시글도 같이 삭제됨

## 고민한 부분
cascade delete를 어떻게 구현할까하다가 TypeOrm에서 Entity에 제공해준다...
@ManyToOne 어노테이션 옵션에 { onDelete: "CASCADE" }를 붙여주기만 하면 된다
TypeOrm은 어마어마한 것 같다!!

## 리뷰 포인트
화이팅☺️

## 관련된 이슈 넘버
#81 #98 #99 