### PR TITLE
게시글 조회, 생성, 수정 API 구현

### DIFF
--- a/backend/src/album/album.entity.ts
+++ b/backend/src/album/album.entity.ts
@@ -11,6 +11,9 @@ export class Album extends TimeStampEntity {
   @Column()
   albumName: string;
 
+  @Column()
+  base: boolean;
+
   @ManyToOne(() => Group, group => group.albums, { onDelete: "CASCADE" })
   @JoinColumn({ name: "group_id" })
   group: Group;

--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -34,7 +34,7 @@ export class AlbumService {
     if (!album) throw new NotFoundException("Can not find Album");
 
     album.albumName = albumName;
-    await this.albumRepository.save(album);
+    this.albumRepository.save(album);
 
     return "AlbumInfo update success!!";
   }
@@ -43,7 +43,7 @@ export class AlbumService {
     const album = await this.albumRepository.findOne(albumId);
     if (!album) throw new NotFoundException("Can not find Album");
 
-    await this.albumRepository.softDelete({ albumId });
+    this.albumRepository.softDelete({ albumId });
 
     return "Album delete success!!";
   }

--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -21,6 +21,7 @@ export class AlbumService {
 
     const album = await this.albumRepository.save({
       albumName: albumName,
+      base: false,
       group: group,
     });
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,8 +5,9 @@ import { UserModule } from "./user/user.module";
 import { AuthModule } from "./auth/auth.module";
 import { GroupModule } from "./group/group.module";
 import { AlbumModule } from "./album/album.module";
+import { PostModule } from "./post/post.module";
 
 @Module({
-  imports: [TypeOrmModule.forRoot(typeORMConfig), UserModule, AuthModule, GroupModule, AlbumModule],
+  imports: [TypeOrmModule.forRoot(typeORMConfig), UserModule, AuthModule, GroupModule, AlbumModule, PostModule],
 })
 export class AppModule {}

--- a/backend/src/auth/service/auth.service.ts
+++ b/backend/src/auth/service/auth.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@nestjs/common";
-import { UserInfoDto } from "src/dto/user/userInfo.dto";
+import { UserInfo } from "src/dto/user/userInfo.dto";
 import { JwtService } from "@nestjs/jwt";
 import { UserService } from "src/user/service/user.service";
 import { User } from "../../user/user.entity";
@@ -8,7 +8,7 @@ import { User } from "../../user/user.entity";
 export class AuthService {
   constructor(private userService: UserService, private jwtService: JwtService) {}
 
-  async validateUser(registerUserDto: UserInfoDto): Promise<User | undefined> {
+  async validateUser(registerUserDto: UserInfo): Promise<User | undefined> {
     const user = await this.userService.registeredUser(registerUserDto);
 
     return user;

--- a/backend/src/auth/strategy/naver.strategy.ts
+++ b/backend/src/auth/strategy/naver.strategy.ts
@@ -1,7 +1,7 @@
 import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
 import { Strategy } from "passport-naver-v2";
-import { UserInfoDto } from "src/dto/user/userInfo.dto";
+import { UserInfo } from "src/dto/user/userInfo.dto";
 import { AuthService } from "../service/auth.service";
 
 @Injectable()
@@ -16,7 +16,7 @@ export class NaverStrategy extends PassportStrategy(Strategy, "naver") {
 
   async validate(naverAccessToken: string, naverRefreshToken: string, profile: any): Promise<{ accessToken: string }> {
     const { email, nickname, profileImage } = profile;
-    const registerUserDto: UserInfoDto = new UserInfoDto();
+    const registerUserDto: UserInfo = new UserInfo();
     registerUserDto.userEmail = email;
     registerUserDto.userNickname = nickname;
     registerUserDto.profileImage = profileImage;

--- a/backend/src/dto/group/getGroupInfoResponse.dto.ts
+++ b/backend/src/dto/group/getGroupInfoResponse.dto.ts
@@ -1,5 +1,5 @@
 import { IsArray, IsNotEmpty, IsString } from "class-validator";
-import { UserInfoDto } from "../user/userInfo.dto";
+import { UserInfo } from "../user/userInfo.dto";
 
 export class GetGroupInfoResponseDto {
   @IsString()
@@ -8,5 +8,5 @@ export class GetGroupInfoResponseDto {
 
   @IsArray()
   @IsNotEmpty()
-  users: UserInfoDto[];
+  users: UserInfo[];
 }

--- a/backend/src/dto/image/imageInfo.ts
+++ b/backend/src/dto/image/imageInfo.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class ImageInfo {
+  @IsString()
+  @IsNotEmpty()
+  imageUrl: string;
+}

--- a/backend/src/dto/post/createPostRequest.dto.ts
+++ b/backend/src/dto/post/createPostRequest.dto.ts
@@ -1,0 +1,39 @@
+import { IsArray, IsDate, IsDecimal, IsNotEmpty, IsNumber, IsOptional, IsString } from "class-validator";
+
+export class CreatePostRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  postTitle: string;
+
+  @IsString()
+  @IsOptional()
+  postContent: string;
+
+  @IsArray()
+  @IsNotEmpty()
+  postImage: string[];
+
+  @IsString()
+  @IsNotEmpty()
+  postDate: string;
+
+  @IsString()
+  @IsNotEmpty()
+  postLocation: string;
+
+  @IsNumber()
+  @IsNotEmpty()
+  postLatitude: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  postLongitude: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  userId: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  albumId: number;
+}

--- a/backend/src/dto/post/createPostRequest.dto.ts
+++ b/backend/src/dto/post/createPostRequest.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsDate, IsDecimal, IsNotEmpty, IsNumber, IsOptional, IsString } from "class-validator";
+import { IsArray, IsNotEmpty, IsNumber, IsOptional, IsString } from "class-validator";
 
 export class CreatePostRequestDto {
   @IsString()

--- a/backend/src/dto/post/createPostRequest.dto.ts
+++ b/backend/src/dto/post/createPostRequest.dto.ts
@@ -1,33 +1,10 @@
-import { IsArray, IsNotEmpty, IsNumber, IsOptional, IsString } from "class-validator";
+import { IsNotEmpty, IsNumber, IsArray } from "class-validator";
+import { PostInfo } from "./postInfo";
 
-export class CreatePostRequestDto {
-  @IsString()
-  @IsNotEmpty()
-  postTitle: string;
-
-  @IsString()
-  @IsOptional()
-  postContent: string;
-
+export class CreatePostRequestDto extends PostInfo {
   @IsArray()
   @IsNotEmpty()
   postImages: string[];
-
-  @IsString()
-  @IsNotEmpty()
-  postDate: string;
-
-  @IsString()
-  @IsNotEmpty()
-  postLocation: string;
-
-  @IsNumber()
-  @IsNotEmpty()
-  postLatitude: number;
-
-  @IsNumber()
-  @IsNotEmpty()
-  postLongitude: number;
 
   @IsNumber()
   @IsNotEmpty()

--- a/backend/src/dto/post/createPostRequest.dto.ts
+++ b/backend/src/dto/post/createPostRequest.dto.ts
@@ -8,9 +8,5 @@ export class CreatePostRequestDto extends PostInfo {
 
   @IsNumber()
   @IsNotEmpty()
-  userId: number;
-
-  @IsNumber()
-  @IsNotEmpty()
   albumId: number;
 }

--- a/backend/src/dto/post/createPostRequest.dto.ts
+++ b/backend/src/dto/post/createPostRequest.dto.ts
@@ -11,7 +11,7 @@ export class CreatePostRequestDto {
 
   @IsArray()
   @IsNotEmpty()
-  postImage: string[];
+  postImages: string[];
 
   @IsString()
   @IsNotEmpty()

--- a/backend/src/dto/post/getPostInfoResponse.dto.ts
+++ b/backend/src/dto/post/getPostInfoResponse.dto.ts
@@ -1,7 +1,15 @@
-import { IsArray, IsDate, IsNotEmpty, IsOptional, IsString } from "class-validator";
+import { IsArray, IsDate, IsNotEmpty, IsNumber, IsOptional, IsString } from "class-validator";
 import { ImageInfo } from "../image/imageInfo";
 
 export class GetPostInfoResponseDto {
+  @IsNumber()
+  @IsNotEmpty()
+  userId: number;
+
+  @IsString()
+  @IsNotEmpty()
+  userNickname: string;
+
   @IsString()
   @IsNotEmpty()
   postTitle: string;

--- a/backend/src/dto/post/getPostInfoResponse.dto.ts
+++ b/backend/src/dto/post/getPostInfoResponse.dto.ts
@@ -1,0 +1,24 @@
+import { IsArray, IsDate, IsNotEmpty, IsOptional, IsString } from "class-validator";
+import { ImageInfo } from "../image/imageInfo";
+
+export class GetPostInfoResponseDto {
+  @IsString()
+  @IsNotEmpty()
+  postTitle: string;
+
+  @IsString()
+  @IsOptional()
+  postContent: string;
+
+  @IsArray()
+  @IsNotEmpty()
+  images: ImageInfo[];
+
+  @IsDate()
+  @IsNotEmpty()
+  postDate: Date;
+
+  @IsString()
+  @IsNotEmpty()
+  postLocation: string;
+}

--- a/backend/src/dto/post/postInfo.ts
+++ b/backend/src/dto/post/postInfo.ts
@@ -1,0 +1,27 @@
+import { IsNotEmpty, IsNumber, IsOptional, IsString } from "class-validator";
+
+export class PostInfo {
+  @IsString()
+  @IsNotEmpty()
+  postTitle: string;
+
+  @IsString()
+  @IsOptional()
+  postContent: string;
+
+  @IsString()
+  @IsNotEmpty()
+  postDate: Date;
+
+  @IsString()
+  @IsNotEmpty()
+  postLocation: string;
+
+  @IsNumber()
+  @IsNotEmpty()
+  postLatitude: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  postLongitude: number;
+}

--- a/backend/src/dto/post/postInfo.ts
+++ b/backend/src/dto/post/postInfo.ts
@@ -24,4 +24,8 @@ export class PostInfo {
   @IsNumber()
   @IsNotEmpty()
   postLongitude: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  userId: number;
 }

--- a/backend/src/dto/post/updatePostInfoRequest.dto.ts
+++ b/backend/src/dto/post/updatePostInfoRequest.dto.ts
@@ -1,0 +1,12 @@
+import { IsArray, IsNotEmpty } from "class-validator";
+import { PostInfo } from "./postInfo";
+
+export class UpdatePostInfoRequestDto extends PostInfo {
+  @IsArray()
+  @IsNotEmpty()
+  deleteImages: number[];
+
+  @IsArray()
+  @IsNotEmpty()
+  addImages: string[];
+}

--- a/backend/src/dto/post/updatePostInfoRequest.dto.ts
+++ b/backend/src/dto/post/updatePostInfoRequest.dto.ts
@@ -4,7 +4,7 @@ import { PostInfo } from "./postInfo";
 export class UpdatePostInfoRequestDto extends PostInfo {
   @IsArray()
   @IsNotEmpty()
-  deleteImages: number[];
+  deleteImagesId: number[];
 
   @IsArray()
   @IsNotEmpty()

--- a/backend/src/dto/user/userInfo.dto.ts
+++ b/backend/src/dto/user/userInfo.dto.ts
@@ -1,6 +1,6 @@
 import { IsString, IsNotEmpty, IsOptional } from "class-validator";
 
-export class UserInfoDto {
+export class UserInfo {
   @IsString()
   @IsNotEmpty()
   userEmail: string;

--- a/backend/src/group/group.module.ts
+++ b/backend/src/group/group.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { JwtModule } from "@nestjs/jwt";
 import { TypeOrmModule } from "@nestjs/typeorm";
+import { AlbumRepository } from "src/album/album.repository";
 import { UserRepository } from "src/user/user.repository";
 import { GroupController } from "./controller/group.controller";
 import { GroupRepository } from "./group.repository";
@@ -8,7 +9,7 @@ import { GroupService } from "./service/group.service";
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([GroupRepository, UserRepository]),
+    TypeOrmModule.forFeature([GroupRepository, UserRepository, AlbumRepository]),
     JwtModule.register({
       secret: process.env.JWT_SECRET,
     }),

--- a/backend/src/group/group.repository.ts
+++ b/backend/src/group/group.repository.ts
@@ -1,5 +1,21 @@
-import { EntityRepository, Repository } from "typeorm";
+import { EntityRepository, Repository, DeleteResult } from "typeorm";
 import { Group } from "./group.entity";
 
 @EntityRepository(Group)
-export class GroupRepository extends Repository<Group> {}
+export class GroupRepository extends Repository<Group> {
+  async readGroupQuery(groupId: number): Promise<Group> {
+    return await this.createQueryBuilder("group")
+      .leftJoin("group.users", "user")
+      .select(["group.groupCode", "user.profileImage", "user.userNickname", "user.userEmail"])
+      .where("group.groupId = :id", { id: groupId })
+      .getOne();
+  }
+
+  async leaveGroupQuery(groupId: number, userId: number): Promise<DeleteResult> {
+    return await this.createQueryBuilder()
+      .delete()
+      .from("users_groups_TB")
+      .where("groups_tb_group_id = :groupId AND users_user_id = :userId", { groupId: groupId, userId: userId })
+      .execute();
+  }
+}

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { GroupRepository } from "../group.repository";
 import { UserRepository } from "src/user/user.repository";
+import { AlbumRepository } from "src/album/album.repository";
 import { Group } from "../group.entity";
 import { CreateGroupRequestDto } from "src/dto/group/createGroupRequest.dto";
 import { AttendGroupRequestDto } from "src/dto/group/attendGroupRequest.dto";
@@ -17,6 +18,8 @@ export class GroupService {
     private groupRepository: GroupRepository,
     @InjectRepository(UserRepository)
     private userRepository: UserRepository,
+    @InjectRepository(AlbumRepository)
+    private albumRepository: AlbumRepository,
   ) {}
 
   async createGroup(createGroupRequestDto: CreateGroupRequestDto): Promise<number> {
@@ -27,6 +30,12 @@ export class GroupService {
       groupImage: groupImage,
       groupName: groupName,
       groupCode: groupCode,
+    });
+
+    await this.albumRepository.save({
+      albumName: "기본 앨범",
+      base: true,
+      group: group,
     });
 
     const user = await this.userRepository.findOne(userId, { relations: ["groups"] });

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -61,7 +61,7 @@ export class GroupService {
 
   async getGroupInfo(groupId: number): Promise<GetGroupInfoResponseDto> {
     const group = await this.readGroupQuery(groupId);
-    if (!group) throw new NotFoundException("Not found group with the id " + groupId);
+    if (!group) throw new NotFoundException(`Not found group with the id ${groupId}`);
 
     const { groupCode, users } = group;
     return { groupCode, users };

--- a/backend/src/image/image.entity.ts
+++ b/backend/src/image/image.entity.ts
@@ -1,0 +1,16 @@
+import { TimeStampEntity } from "src/myBaseEntity/timestampEntity";
+import { Post } from "src/post/post.entity";
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity({ name: "images" })
+export class Image extends TimeStampEntity {
+  @PrimaryGeneratedColumn()
+  imageId: number;
+
+  @Column()
+  imageUrl: string;
+
+  @ManyToOne(() => Post, post => post.images, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "post_id" })
+  post: Post;
+}

--- a/backend/src/image/image.module.ts
+++ b/backend/src/image/image.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { ImageService } from "./service/image.service";
+import { ImageRepository } from "./image.repository";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ImageRepository])],
+  providers: [ImageService],
+  exports: [ImageService],
+})
+export class ImageModule {}

--- a/backend/src/image/image.repository.ts
+++ b/backend/src/image/image.repository.ts
@@ -1,0 +1,5 @@
+import { EntityRepository, Repository } from "typeorm";
+import { Image } from "./image.entity";
+
+@EntityRepository(Image)
+export class ImageRepository extends Repository<Image> {}

--- a/backend/src/image/service/image.service.ts
+++ b/backend/src/image/service/image.service.ts
@@ -18,4 +18,10 @@ export class ImageService {
       });
     });
   }
+
+  deleteImage(images: number[]): void {
+    images.forEach(imageId => {
+      this.imageRepository.softDelete({ imageId });
+    });
+  }
 }

--- a/backend/src/image/service/image.service.ts
+++ b/backend/src/image/service/image.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { ImageRepository } from "../image.repository";
 import { Post } from "src/post/post.entity";
+
 @Injectable()
 export class ImageService {
   constructor(

--- a/backend/src/image/service/image.service.ts
+++ b/backend/src/image/service/image.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { ImageRepository } from "../image.repository";
+import { Post } from "src/post/post.entity";
+@Injectable()
+export class ImageService {
+  constructor(
+    @InjectRepository(ImageRepository)
+    private imageRepository: ImageRepository,
+  ) {}
+
+  saveImage(post: Post, images: string[]): void {
+    images.forEach(e => {
+      this.imageRepository.save({
+        imageUrl: e,
+        post: post,
+      });
+    });
+  }
+}

--- a/backend/src/post/controller/post.controller.spec.ts
+++ b/backend/src/post/controller/post.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { PostController } from "./post.controller";
+
+describe("PostController", () => {
+  let controller: PostController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PostController],
+    }).compile();
+
+    controller = module.get<PostController>(PostController);
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/post/controller/post.controller.ts
+++ b/backend/src/post/controller/post.controller.ts
@@ -1,8 +1,9 @@
-import { Body, Controller, Get, HttpCode, Param, Post, UseGuards } from "@nestjs/common";
+import { Body, Controller, Get, HttpCode, Param, Post, Put, UseGuards } from "@nestjs/common";
 import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
 import { PostService } from "../service/post.service";
 import { CreatePostRequestDto } from "src/dto/post/createPostRequest.dto";
 import { GetPostInfoResponseDto } from "src/dto/post/getPostInfoResponse.dto";
+import { UpdatePostInfoRequestDto } from "src/dto/post/updatePostInfoRequest.dto";
 
 @UseGuards(JwtAuthGuard)
 @Controller("api/posts")
@@ -18,5 +19,13 @@ export class PostController {
   @Get("/:postId")
   GetPostInfo(@Param("postId") postId: number): Promise<GetPostInfoResponseDto> {
     return this.postService.getPostInfo(postId);
+  }
+
+  @Put("/:postId")
+  UpdatePost(
+    @Param("postId") postId: number,
+    @Body() updatePostInfoRequestDto: UpdatePostInfoRequestDto,
+  ): Promise<string> {
+    return this.postService.updatePostInfo(postId, updatePostInfoRequestDto);
   }
 }

--- a/backend/src/post/controller/post.controller.ts
+++ b/backend/src/post/controller/post.controller.ts
@@ -1,7 +1,8 @@
-import { Body, Controller, HttpCode, Post, UseGuards } from "@nestjs/common";
+import { Body, Controller, Get, HttpCode, Param, Post, UseGuards } from "@nestjs/common";
 import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
 import { PostService } from "../service/post.service";
 import { CreatePostRequestDto } from "src/dto/post/createPostRequest.dto";
+import { GetPostInfoResponseDto } from "src/dto/post/getPostInfoResponse.dto";
 
 @UseGuards(JwtAuthGuard)
 @Controller("api/posts")
@@ -12,5 +13,10 @@ export class PostController {
   @HttpCode(200)
   CreatePost(@Body() createPostRequestDto: CreatePostRequestDto): Promise<number> {
     return this.postService.createPost(createPostRequestDto);
+  }
+
+  @Get("/:postId")
+  GetPostInfo(@Param("postId") postId: number): Promise<GetPostInfoResponseDto> {
+    return this.postService.getPostInfo(postId);
   }
 }

--- a/backend/src/post/controller/post.controller.ts
+++ b/backend/src/post/controller/post.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from "@nestjs/common";
+
+@Controller("api/posts")
+export class PostController {}

--- a/backend/src/post/controller/post.controller.ts
+++ b/backend/src/post/controller/post.controller.ts
@@ -1,4 +1,16 @@
-import { Controller } from "@nestjs/common";
+import { Body, Controller, HttpCode, Post, UseGuards } from "@nestjs/common";
+import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
+import { PostService } from "../service/post.service";
+import { CreatePostRequestDto } from "src/dto/post/createPostRequest.dto";
 
+@UseGuards(JwtAuthGuard)
 @Controller("api/posts")
-export class PostController {}
+export class PostController {
+  constructor(private readonly postService: PostService) {}
+
+  @Post()
+  @HttpCode(200)
+  CreatePost(@Body() createPostRequestDto: CreatePostRequestDto): Promise<number> {
+    return this.postService.createPost(createPostRequestDto);
+  }
+}

--- a/backend/src/post/post.entity.ts
+++ b/backend/src/post/post.entity.ts
@@ -16,7 +16,7 @@ export class Post extends TimeStampEntity {
   postContent: string;
 
   @Column()
-  rememberDate: Date;
+  postDate: Date;
 
   @Column()
   postLocation: string;

--- a/backend/src/post/post.entity.ts
+++ b/backend/src/post/post.entity.ts
@@ -1,6 +1,8 @@
 import { Album } from "src/album/album.entity";
 import { TimeStampEntity } from "src/myBaseEntity/timestampEntity";
-import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from "typeorm";
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn, OneToMany } from "typeorm";
+import { Image } from "src/image/image.entity";
+import { User } from "src/user/user.entity";
 
 @Entity({ name: "posts" })
 export class Post extends TimeStampEntity {
@@ -28,4 +30,11 @@ export class Post extends TimeStampEntity {
   @ManyToOne(() => Album, album => album.posts, { onDelete: "CASCADE" })
   @JoinColumn({ name: "album_id" })
   album: Album;
+
+  @ManyToOne(() => User, user => user.posts, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "user_id" })
+  user: User;
+
+  @OneToMany(() => Image, image => image.post)
+  images: Image[];
 }

--- a/backend/src/post/post.module.ts
+++ b/backend/src/post/post.module.ts
@@ -4,10 +4,14 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { PostController } from "./controller/post.controller";
 import { PostService } from "./service/post.service";
 import { PostRepository } from "./post.repository";
+import { UserRepository } from "src/user/user.repository";
+import { AlbumRepository } from "src/album/album.repository";
+import { ImageModule } from "src/image/image.module";
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([PostRepository]),
+    ImageModule,
+    TypeOrmModule.forFeature([PostRepository, UserRepository, AlbumRepository]),
     JwtModule.register({
       secret: process.env.JWT_SECRET,
     }),

--- a/backend/src/post/post.module.ts
+++ b/backend/src/post/post.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { JwtModule } from "@nestjs/jwt";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { PostController } from "./controller/post.controller";
+import { PostService } from "./service/post.service";
+import { PostRepository } from "./post.repository";
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([PostRepository]),
+    JwtModule.register({
+      secret: process.env.JWT_SECRET,
+    }),
+  ],
+  controllers: [PostController],
+  providers: [PostService],
+})
+export class PostModule {}

--- a/backend/src/post/post.repository.ts
+++ b/backend/src/post/post.repository.ts
@@ -1,0 +1,5 @@
+import { EntityRepository, Repository } from "typeorm";
+import { Post } from "./post.entity";
+
+@EntityRepository(Post)
+export class PostRepository extends Repository<Post> {}

--- a/backend/src/post/post.repository.ts
+++ b/backend/src/post/post.repository.ts
@@ -2,4 +2,12 @@ import { EntityRepository, Repository } from "typeorm";
 import { Post } from "./post.entity";
 
 @EntityRepository(Post)
-export class PostRepository extends Repository<Post> {}
+export class PostRepository extends Repository<Post> {
+  async readPostQuery(postId: number): Promise<Post> {
+    return await this.createQueryBuilder("post")
+      .leftJoin("post.images", "image")
+      .select(["post.postTitle", "post.postContent", "post.postDate", "post.postLocation", "image.imageUrl"])
+      .where("post.postId = :id", { id: postId })
+      .getOne();
+  }
+}

--- a/backend/src/post/post.repository.ts
+++ b/backend/src/post/post.repository.ts
@@ -6,7 +6,14 @@ export class PostRepository extends Repository<Post> {
   async readPostQuery(postId: number): Promise<Post> {
     return await this.createQueryBuilder("post")
       .leftJoin("post.images", "image")
-      .select(["post.postTitle", "post.postContent", "post.postDate", "post.postLocation", "image.imageUrl"])
+      .select([
+        "post.postTitle",
+        "post.postContent",
+        "post.postDate",
+        "post.postLocation",
+        "image.imageUrl",
+        "image.imageId",
+      ])
       .where("post.postId = :id", { id: postId })
       .getOne();
   }

--- a/backend/src/post/service/post.service.spec.ts
+++ b/backend/src/post/service/post.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { PostService } from "./post.service";
+
+describe("PostService", () => {
+  let service: PostService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PostService],
+    }).compile();
+
+    service = module.get<PostService>(PostService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/post/service/post.service.ts
+++ b/backend/src/post/service/post.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class PostService {}

--- a/backend/src/post/service/post.service.ts
+++ b/backend/src/post/service/post.service.ts
@@ -6,6 +6,7 @@ import { UserRepository } from "src/user/user.repository";
 import { AlbumRepository } from "src/album/album.repository";
 import { CreatePostRequestDto } from "src/dto/post/createPostRequest.dto";
 import { GetPostInfoResponseDto } from "src/dto/post/getPostInfoResponse.dto";
+import { UpdatePostInfoRequestDto } from "src/dto/post/updatePostInfoRequest.dto";
 
 @Injectable()
 export class PostService {
@@ -24,7 +25,7 @@ export class PostService {
       createPostRequestDto;
 
     const user = await this.userRepository.findOne({ userId });
-    if (!user) throw new NotFoundException(`Not found usseleer with the id ${userId}`);
+    if (!user) throw new NotFoundException(`Not found user with the id ${userId}`);
 
     const album = await this.albumRepository.findOne({ albumId });
     if (!album) throw new NotFoundException(`Not found album with the id ${albumId}`);
@@ -50,5 +51,24 @@ export class PostService {
     const { postTitle, postContent, postDate, postLocation, images } = post;
 
     return { postTitle, postContent, postDate, postLocation, images };
+  }
+
+  async updatePostInfo(postId: number, updatePostInfoRequestDto: UpdatePostInfoRequestDto): Promise<string> {
+    const { postTitle, postContent, deleteImages, addImages, postDate, postLocation, postLatitude, postLongitude } =
+      updatePostInfoRequestDto;
+    const post = await this.postRepository.findOne({ postId });
+
+    post.postTitle = postTitle;
+    post.postContent = postContent;
+    post.postDate = postDate;
+    post.postLocation = postLocation;
+    post.postLatitude = postLatitude;
+    post.postLongitude = postLongitude;
+    this.postRepository.save(post);
+
+    this.imageService.saveImage(post, addImages);
+    this.imageService.deleteImage(deleteImages);
+
+    return "PostInfo update success!!";
   }
 }

--- a/backend/src/post/service/post.service.ts
+++ b/backend/src/post/service/post.service.ts
@@ -1,4 +1,46 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { ImageService } from "src/image/service/image.service";
+import { InjectRepository } from "@nestjs/typeorm";
+import { PostRepository } from "../post.repository";
+import { UserRepository } from "src/user/user.repository";
+import { AlbumRepository } from "src/album/album.repository";
+import { CreatePostRequestDto } from "src/dto/post/createPostRequest.dto";
 
 @Injectable()
-export class PostService {}
+export class PostService {
+  constructor(
+    private readonly imageService: ImageService,
+    @InjectRepository(PostRepository)
+    private postRepository: PostRepository,
+    @InjectRepository(UserRepository)
+    private userRepository: UserRepository,
+    @InjectRepository(AlbumRepository)
+    private albumRepository: AlbumRepository,
+  ) {}
+
+  async createPost(createPostRequestDto: CreatePostRequestDto): Promise<number> {
+    const { postTitle, postContent, postImage, postDate, postLocation, postLatitude, postLongitude, userId, albumId } =
+      createPostRequestDto;
+
+    const user = await this.userRepository.findOne({ userId });
+    if (!user) throw new NotFoundException(`Not found usseleer with the id ${userId}`);
+
+    const album = await this.albumRepository.findOne({ albumId });
+    if (!album) throw new NotFoundException(`Not found album with the id ${albumId}`);
+
+    const post = await this.postRepository.save({
+      postTitle: postTitle,
+      postContent: postContent,
+      postDate: postDate,
+      postLocation: postLocation,
+      postLatitude: postLatitude,
+      postLongitude: postLongitude,
+      user: user,
+      album: album,
+    });
+
+    this.imageService.saveImage(post, postImage);
+
+    return post.postId;
+  }
+}

--- a/backend/src/post/service/post.service.ts
+++ b/backend/src/post/service/post.service.ts
@@ -48,9 +48,10 @@ export class PostService {
 
   async getPostInfo(postId: number): Promise<GetPostInfoResponseDto> {
     const post = await this.postRepository.readPostQuery(postId);
-    const { postTitle, postContent, postDate, postLocation, images } = post;
-
-    return { postTitle, postContent, postDate, postLocation, images };
+    const { user, postTitle, postContent, postDate, postLocation, images } = post;
+    const userId = user.userId;
+    const userNickname = user.userNickname;
+    return { userId, userNickname, postTitle, postContent, postDate, postLocation, images };
   }
 
   async updatePostInfo(postId: number, updatePostInfoRequestDto: UpdatePostInfoRequestDto): Promise<string> {

--- a/backend/src/post/service/post.service.ts
+++ b/backend/src/post/service/post.service.ts
@@ -58,7 +58,7 @@ export class PostService {
     const {
       postTitle,
       postContent,
-      deleteImages,
+      deleteImagesId,
       addImages,
       postDate,
       postLocation,
@@ -80,7 +80,7 @@ export class PostService {
     this.postRepository.save(post);
 
     this.imageService.saveImage(post, addImages);
-    this.imageService.deleteImage(deleteImages);
+    this.imageService.deleteImage(deleteImagesId);
 
     return "PostInfo update success!!";
   }

--- a/backend/src/post/service/post.service.ts
+++ b/backend/src/post/service/post.service.ts
@@ -5,6 +5,7 @@ import { PostRepository } from "../post.repository";
 import { UserRepository } from "src/user/user.repository";
 import { AlbumRepository } from "src/album/album.repository";
 import { CreatePostRequestDto } from "src/dto/post/createPostRequest.dto";
+import { GetPostInfoResponseDto } from "src/dto/post/getPostInfoResponse.dto";
 
 @Injectable()
 export class PostService {
@@ -19,7 +20,7 @@ export class PostService {
   ) {}
 
   async createPost(createPostRequestDto: CreatePostRequestDto): Promise<number> {
-    const { postTitle, postContent, postImage, postDate, postLocation, postLatitude, postLongitude, userId, albumId } =
+    const { postTitle, postContent, postImages, postDate, postLocation, postLatitude, postLongitude, userId, albumId } =
       createPostRequestDto;
 
     const user = await this.userRepository.findOne({ userId });
@@ -39,8 +40,15 @@ export class PostService {
       album: album,
     });
 
-    this.imageService.saveImage(post, postImage);
+    this.imageService.saveImage(post, postImages);
 
     return post.postId;
+  }
+
+  async getPostInfo(postId: number): Promise<GetPostInfoResponseDto> {
+    const post = await this.postRepository.readPostQuery(postId);
+    const { postTitle, postContent, postDate, postLocation, images } = post;
+
+    return { postTitle, postContent, postDate, postLocation, images };
   }
 }

--- a/backend/src/post/service/post.service.ts
+++ b/backend/src/post/service/post.service.ts
@@ -54,9 +54,21 @@ export class PostService {
   }
 
   async updatePostInfo(postId: number, updatePostInfoRequestDto: UpdatePostInfoRequestDto): Promise<string> {
-    const { postTitle, postContent, deleteImages, addImages, postDate, postLocation, postLatitude, postLongitude } =
-      updatePostInfoRequestDto;
+    const {
+      postTitle,
+      postContent,
+      deleteImages,
+      addImages,
+      postDate,
+      postLocation,
+      postLatitude,
+      postLongitude,
+      userId,
+    } = updatePostInfoRequestDto;
+
     const post = await this.postRepository.findOne({ postId });
+    const postUserId = post.user.userId;
+    if (postUserId !== userId) throw new NotFoundException("It cannot be updated because it is not the author.");
 
     post.postTitle = postTitle;
     post.postContent = postContent;

--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { UserInfoDto } from "src/dto/user/userInfo.dto";
+import { UserInfo } from "src/dto/user/userInfo.dto";
 import { User } from "../user.entity";
 import { UserRepository } from "../user.repository";
 import { UserInfoResponseDto } from "src/dto/user/userInfoResponse.dto";
@@ -13,7 +13,7 @@ export class UserService {
     private userRepository: UserRepository,
   ) {}
 
-  async registeredUser(registerUserDto: UserInfoDto): Promise<User | undefined> {
+  async registeredUser(registerUserDto: UserInfo): Promise<User | undefined> {
     const userEmail = registerUserDto.userEmail;
 
     let user = await this.userRepository.findOne({ userEmail });

--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -39,7 +39,7 @@ export class UserService {
 
     user.profileImage = profileImage;
     user.userNickname = userNickname;
-    await this.userRepository.save(user);
+    this.userRepository.save(user);
 
     return "UserInfo update success!!";
   }

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -1,6 +1,7 @@
-import { Entity, Column, PrimaryGeneratedColumn, ManyToMany, JoinTable } from "typeorm";
+import { Entity, Column, PrimaryGeneratedColumn, ManyToMany, JoinTable, OneToMany } from "typeorm";
 import { TimeStampEntity } from "src/myBaseEntity/timestampEntity";
 import { Group } from "src/group/group.entity";
+import { Post } from "src/post/post.entity";
 
 @Entity({ name: "users" })
 export class User extends TimeStampEntity {
@@ -19,4 +20,7 @@ export class User extends TimeStampEntity {
   @ManyToMany(() => Group)
   @JoinTable({ name: "users_groups_TB" })
   groups: Group[];
+
+  @OneToMany(() => Post, post => post.user)
+  posts: Post[];
 }

--- a/backend/src/user/user.repository.ts
+++ b/backend/src/user/user.repository.ts
@@ -1,10 +1,10 @@
-import { UserInfoDto } from "src/dto/user/userInfo.dto";
+import { UserInfo } from "src/dto/user/userInfo.dto";
 import { EntityRepository, Repository } from "typeorm";
 import { User } from "./user.entity";
 
 @EntityRepository(User)
 export class UserRepository extends Repository<User> {
-  async saveUser(registerUserDto: UserInfoDto): Promise<User> {
+  async saveUser(registerUserDto: UserInfo): Promise<User> {
     const user = this.create(registerUserDto);
 
     return await this.save(user);


### PR DESCRIPTION
## 작업 내용
- 게시글 조회 API
  - Param : postId
  - Response
    - userId, userNickname, postTitle, postContent, postImages(imageUrl, imageId)-배열, postDate, postLocation
- 게시글 수정 API
  - Body
    - userId, postTitle, postContent, deleteImagesId(배열), addImages(배열), postDate, postLocation, postLatitude, postLongitude
  - Response : Status Code(200)
- 게시글 생성 API
  - Body
    - userId, postTitle, postContent, postImages-배열, postDate, postLocation, postLatitude, postLongitude, albumId
  - Response : Status Code(200), postId
  
## 고민한 부분
- 모든 DB 접근 시 습관적으로 await를 붙여줬는데 필요없는 부분을 제거했습니다.
- 아직 object storage를 사용중이지 않아서 이미지 요청 시 string으로 받게 처리했습니다.

## 리뷰 포인트
- save하고 끝내버리는 로직의 경우 await를 빼서 동기적으로 작동하게 변경
- 급하게 짜느라 DB 쿼리문을 최적화 하지 못한 느낌입니다...계속해서 수정해야할 것 같아요!

## 관련된 이슈 넘버
#80 #79 #106 