### PR TITLE
남은 게시글 API 구현 및 JWT refreshToken 생성, 로그아웃 구현

### DIFF
--- a/backend/src/album/album.entity.ts
+++ b/backend/src/album/album.entity.ts
@@ -18,6 +18,6 @@ export class Album extends TimeStampEntity {
   @JoinColumn({ name: "group_id" })
   group: Group;
 
-  @OneToMany(() => Post, post => post.album)
+  @OneToMany(() => Post, post => post.album, { cascade: true })
   posts: Post[];
 }

--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -33,8 +33,7 @@ export class AlbumService {
     const album = await this.albumRepository.findOne({ albumId });
     if (!album) throw new NotFoundException(`Not found album with the id ${albumId}`);
 
-    album.albumName = albumName;
-    this.albumRepository.save(album);
+    this.albumRepository.update(albumId, { albumName });
 
     return "AlbumInfo update success!!";
   }

--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -43,7 +43,7 @@ export class AlbumService {
     const album = await this.albumRepository.findOne(albumId, { relations: ["posts"] });
     if (!album) throw new NotFoundException(`Not found album with the id ${albumId}`);
 
-    this.albumRepository.softDelete({ albumId });
+    this.albumRepository.softRemove(album);
 
     return "Album delete success!!";
   }

--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -31,7 +31,7 @@ export class AlbumService {
   async updateAlbumInfo(albumId: number, updateAlbumInfoRequestDto: UpdateAlbumInfoRequestDto): Promise<string> {
     const { albumName } = updateAlbumInfoRequestDto;
     const album = await this.albumRepository.findOne({ albumId });
-    if (!album) throw new NotFoundException("Can not find Album");
+    if (!album) throw new NotFoundException(`Not found album with the id ${albumId}`);
 
     album.albumName = albumName;
     this.albumRepository.save(album);
@@ -41,7 +41,7 @@ export class AlbumService {
 
   async deleteAlbum(albumId: number): Promise<string> {
     const album = await this.albumRepository.findOne(albumId);
-    if (!album) throw new NotFoundException("Can not find Album");
+    if (!album) throw new NotFoundException(`Not found album with the id ${albumId}`);
 
     this.albumRepository.softDelete({ albumId });
 

--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -40,7 +40,7 @@ export class AlbumService {
   }
 
   async deleteAlbum(albumId: number): Promise<string> {
-    const album = await this.albumRepository.findOne(albumId);
+    const album = await this.albumRepository.findOne(albumId, { relations: ["posts"] });
     if (!album) throw new NotFoundException(`Not found album with the id ${albumId}`);
 
     this.albumRepository.softDelete({ albumId });

--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -1,10 +1,7 @@
 import { Controller, Get, Req, Res, UseGuards } from "@nestjs/common";
-import { Request, Response } from "express";
+import { Response } from "express";
 import { NaverOauthGuard } from "../guard/naver-auth.guard";
-
-interface myRequest extends Request {
-  user: { accessToken: string };
-}
+import { CustomRequest } from "src/myRequest/customRequest";
 
 @Controller("/api/login")
 export class AuthController {
@@ -16,10 +13,11 @@ export class AuthController {
 
   @Get("/oauth/callback")
   @UseGuards(NaverOauthGuard)
-  async naverAuthRedirect(@Req() req: myRequest, @Res() res: Response) {
-    const accessToken = req.user.accessToken;
+  async naverAuthRedirect(@Req() req: CustomRequest, @Res() res: Response) {
+    const { accessToken, refreshToken } = req.user;
 
     res.cookie("accessToken", accessToken);
+    res.cookie("refreshToken", refreshToken);
     res.redirect("/");
     res.end();
   }

--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -1,24 +1,39 @@
-import { Controller, Get, Req, Res, UseGuards } from "@nestjs/common";
+import { Controller, Get, Post, Req, Res, UseGuards } from "@nestjs/common";
 import { Response } from "express";
 import { NaverOauthGuard } from "../guard/naver-auth.guard";
+import { JwtAuthGuard } from "../guard/jwt-auth-guard";
 import { CustomRequest } from "src/myRequest/customRequest";
+import { UserService } from "src/user/service/user.service";
 
-@Controller("/api/login")
+@Controller("/api/auth")
 export class AuthController {
-  @Get()
+  constructor(private readonly userService: UserService) {}
+
+  @Get("/login")
   @UseGuards(NaverOauthGuard)
   async naverAuth() {
     return;
   }
 
-  @Get("/oauth/callback")
+  @Get("/login/oauth/callback")
   @UseGuards(NaverOauthGuard)
-  async naverAuthRedirect(@Req() req: CustomRequest, @Res() res: Response) {
-    const { accessToken, refreshToken } = req.user;
+  async naverAuthRedirect(@Req() { user }: CustomRequest, @Res() res: Response) {
+    const { accessToken, refreshToken } = user;
 
     res.cookie("accessToken", accessToken);
     res.cookie("refreshToken", refreshToken);
     res.redirect("/");
+  }
+
+  @Post("/logout")
+  @UseGuards(JwtAuthGuard)
+  async logOut(@Req() { user }: CustomRequest, @Res() res: Response): Promise<void> {
+    const { userId } = user;
+
+    await this.userService.updateToken(userId, null);
+
+    res.clearCookie("accessToken");
+    res.clearCookie("refreshToken");
     res.end();
   }
 }

--- a/backend/src/auth/guard/jwt-auth-guard.ts
+++ b/backend/src/auth/guard/jwt-auth-guard.ts
@@ -7,6 +7,7 @@ export class JwtAuthGuard extends AuthGuard("jwt") {
   constructor(private jwtService: JwtService) {
     super();
   }
+
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
     const response = context.switchToHttp().getResponse();
@@ -14,6 +15,7 @@ export class JwtAuthGuard extends AuthGuard("jwt") {
     const { accessToken, refreshToken } = request.cookies;
 
     const validationAccessToken = await this.validateToken(accessToken);
+
     if (validationAccessToken) {
       request.user = validationAccessToken;
       return true;
@@ -33,6 +35,7 @@ export class JwtAuthGuard extends AuthGuard("jwt") {
 
   async validateToken(token: string): Promise<{ userId: number }> {
     const { userId } = await this.jwtService.verify(token);
+
     return { userId: userId };
   }
 

--- a/backend/src/auth/guard/jwt-auth-guard.ts
+++ b/backend/src/auth/guard/jwt-auth-guard.ts
@@ -1,7 +1,6 @@
 import { ExecutionContext, Injectable, UnauthorizedException } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
 import { JwtService } from "@nestjs/jwt";
-import { User } from "../../user/user.entity";
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard("jwt") {
@@ -10,16 +9,39 @@ export class JwtAuthGuard extends AuthGuard("jwt") {
   }
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
+    const response = context.switchToHttp().getResponse();
 
-    const { accessToken } = request.cookies;
+    const { accessToken, refreshToken } = request.cookies;
 
-    const { userId } = await this.validateToken(accessToken);
-    if (!userId) throw new UnauthorizedException("토큰이 존재하지 않습니다.");
+    const validationAccessToken = await this.validateToken(accessToken);
+    if (validationAccessToken) {
+      request.user = validationAccessToken;
+      return true;
+    }
+
+    const validationRefreshToken = await this.validateToken(refreshToken);
+    if (!validationRefreshToken) throw new UnauthorizedException("토큰이 존재하지 않습니다.");
+
+    request.user = validationRefreshToken;
+
+    const { userId } = validationRefreshToken;
+    const updateAccessToken = this.createToken(userId, "1h");
+    response.cookie("accessToken", updateAccessToken);
 
     return true;
   }
 
-  async validateToken(token: string): Promise<User> {
-    return await this.jwtService.verify(token);
+  async validateToken(token: string): Promise<{ userId: number }> {
+    const { userId } = await this.jwtService.verify(token);
+    return { userId: userId };
+  }
+
+  createToken(userId: number, expire: string): string {
+    const payload = {
+      userId: userId,
+      userToken: "loginToken",
+    };
+
+    return this.jwtService.sign(payload, { expiresIn: expire });
   }
 }

--- a/backend/src/auth/service/auth.service.ts
+++ b/backend/src/auth/service/auth.service.ts
@@ -14,12 +14,12 @@ export class AuthService {
     return user;
   }
 
-  createToken(user: User): string {
+  createToken(userId: number, expire: string): string {
     const payload = {
-      userId: user.userId,
+      userId: userId,
       userToken: "loginToken",
     };
 
-    return this.jwtService.sign(payload, { expiresIn: "60m" });
+    return this.jwtService.sign(payload, { expiresIn: expire });
   }
 }

--- a/backend/src/auth/strategy/naver.strategy.ts
+++ b/backend/src/auth/strategy/naver.strategy.ts
@@ -2,11 +2,12 @@ import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
 import { Strategy } from "passport-naver-v2";
 import { UserInfo } from "src/dto/user/userInfo.dto";
+import { UserService } from "src/user/service/user.service";
 import { AuthService } from "../service/auth.service";
 
 @Injectable()
 export class NaverStrategy extends PassportStrategy(Strategy, "naver") {
-  constructor(private authService: AuthService) {
+  constructor(private readonly authService: AuthService, private readonly userService: UserService) {
     super({
       clientID: process.env.NAVER_CLIENT_ID,
       clientSecret: process.env.NAVER_CLIENT_SECRET,
@@ -14,7 +15,11 @@ export class NaverStrategy extends PassportStrategy(Strategy, "naver") {
     });
   }
 
-  async validate(naverAccessToken: string, naverRefreshToken: string, profile: any): Promise<{ accessToken: string }> {
+  async validate(
+    naverAccessToken: string,
+    naverRefreshToken: string,
+    profile: any,
+  ): Promise<{ accessToken: string; refreshToken: string }> {
     const { email, nickname, profileImage } = profile;
     const registerUserDto: UserInfo = new UserInfo();
     registerUserDto.userEmail = email;
@@ -24,8 +29,13 @@ export class NaverStrategy extends PassportStrategy(Strategy, "naver") {
     const user = await this.authService.validateUser(registerUserDto);
     if (!user) throw new UnauthorizedException("유저가 존재하지 않습니다.");
 
-    const accessToken = this.authService.createToken(user);
+    const { userId } = user;
 
-    return { accessToken };
+    const accessToken = this.authService.createToken(userId, "1h");
+    const refreshToken = this.authService.createToken(userId, "7d");
+
+    await this.userService.updateToken(userId, refreshToken);
+
+    return { accessToken, refreshToken };
   }
 }

--- a/backend/src/dto/group/attendGroupRequest.dto.ts
+++ b/backend/src/dto/group/attendGroupRequest.dto.ts
@@ -1,10 +1,6 @@
-import { IsNotEmpty, IsNumber, IsString } from "class-validator";
+import { IsNotEmpty, IsString } from "class-validator";
 
 export class AttendGroupRequestDto {
-  @IsNumber()
-  @IsNotEmpty()
-  userId: number;
-
   @IsString()
   @IsNotEmpty()
   code: string;

--- a/backend/src/dto/group/createGroupRequest.dto.ts
+++ b/backend/src/dto/group/createGroupRequest.dto.ts
@@ -1,8 +1,3 @@
-import { IsNotEmpty, IsNumber } from "class-validator";
 import { GroupInfo } from "./groupInfo";
 
-export class CreateGroupRequestDto extends GroupInfo {
-  @IsNumber()
-  @IsNotEmpty()
-  userId: number;
-}
+export class CreateGroupRequestDto extends GroupInfo {}

--- a/backend/src/dto/group/getAlbumsResponse.dto.ts
+++ b/backend/src/dto/group/getAlbumsResponse.dto.ts
@@ -1,0 +1,39 @@
+import { IsArray, IsNotEmpty, IsNumber, IsString } from "class-validator";
+
+export class GetAlbumsResponseDto {
+  @IsArray()
+  @IsNotEmpty()
+  albums: albumList[];
+}
+
+class albumList {
+  @IsNumber()
+  @IsNotEmpty()
+  albumId: number;
+
+  @IsString()
+  @IsNotEmpty()
+  albumName: string;
+
+  @IsArray()
+  @IsNotEmpty()
+  posts: postList[];
+}
+
+class postList {
+  @IsNumber()
+  @IsNotEmpty()
+  postId: number;
+
+  @IsString()
+  @IsNotEmpty()
+  postTitle: string;
+
+  @IsNumber()
+  @IsNotEmpty()
+  postLatitude: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  postLongitude: number;
+}

--- a/backend/src/dto/group/leaveGroupRequest.dto.ts
+++ b/backend/src/dto/group/leaveGroupRequest.dto.ts
@@ -1,7 +1,0 @@
-import { IsNotEmpty, IsNumber } from "class-validator";
-
-export class LeaveGroupDto {
-  @IsNumber()
-  @IsNotEmpty()
-  userId: number;
-}

--- a/backend/src/dto/post/postInfo.ts
+++ b/backend/src/dto/post/postInfo.ts
@@ -24,8 +24,4 @@ export class PostInfo {
   @IsNumber()
   @IsNotEmpty()
   postLongitude: number;
-
-  @IsNumber()
-  @IsNotEmpty()
-  userId: number;
 }

--- a/backend/src/group/controller/group.controller.ts
+++ b/backend/src/group/controller/group.controller.ts
@@ -6,6 +6,7 @@ import { AttendGroupRequestDto } from "src/dto/group/attendGroupRequest.dto";
 import { GetGroupInfoResponseDto } from "src/dto/group/getGroupInfoResponse.dto";
 import { UpdateGroupInfoRequestDto } from "src/dto/group/updateGroupInfoRequest.dto";
 import { LeaveGroupDto } from "src/dto/group/leaveGroupRequest.dto";
+import { GetAlbumsResponseDto } from "src/dto/group/getAlbumsResponse.dto";
 
 @UseGuards(JwtAuthGuard)
 @Controller("api/groups")
@@ -27,6 +28,11 @@ export class GroupController {
   @Get("/:groupId")
   GetGroupInfo(@Param("groupId") groupId: number): Promise<GetGroupInfoResponseDto> {
     return this.groupService.getGroupInfo(groupId);
+  }
+
+  @Get("/:groupId/albums")
+  GetAlbums(@Param("groupId") groupId: number): Promise<GetAlbumsResponseDto> {
+    return this.groupService.getAlbums(groupId);
   }
 
   @Put("/:groupId")

--- a/backend/src/group/controller/group.controller.ts
+++ b/backend/src/group/controller/group.controller.ts
@@ -1,11 +1,11 @@
-import { Body, Controller, Get, HttpCode, Param, Post, Put, Delete, UseGuards } from "@nestjs/common";
+import { Body, Controller, Req, Get, HttpCode, Param, Post, Put, Delete, UseGuards } from "@nestjs/common";
+import { CustomRequest } from "src/myRequest/customRequest";
 import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
 import { GroupService } from "../service/group.service";
 import { CreateGroupRequestDto } from "src/dto/group/createGroupRequest.dto";
 import { AttendGroupRequestDto } from "src/dto/group/attendGroupRequest.dto";
 import { GetGroupInfoResponseDto } from "src/dto/group/getGroupInfoResponse.dto";
 import { UpdateGroupInfoRequestDto } from "src/dto/group/updateGroupInfoRequest.dto";
-import { LeaveGroupDto } from "src/dto/group/leaveGroupRequest.dto";
 import { GetAlbumsResponseDto } from "src/dto/group/getAlbumsResponse.dto";
 
 @UseGuards(JwtAuthGuard)
@@ -15,14 +15,16 @@ export class GroupController {
 
   @Post()
   @HttpCode(200)
-  CreateGroup(@Body() createGroupRequestDto: CreateGroupRequestDto): Promise<number> {
-    return this.groupService.createGroup(createGroupRequestDto);
+  CreateGroup(@Req() { user }: CustomRequest, @Body() createGroupRequestDto: CreateGroupRequestDto): Promise<number> {
+    const { userId } = user;
+    return this.groupService.createGroup(userId, createGroupRequestDto);
   }
 
   @Post("/join")
   @HttpCode(200)
-  AttendGroup(@Body() attendGroupRequestDto: AttendGroupRequestDto): Promise<number> {
-    return this.groupService.attendGroup(attendGroupRequestDto);
+  AttendGroup(@Req() { user }: CustomRequest, @Body() attendGroupRequestDto: AttendGroupRequestDto): Promise<number> {
+    const { userId } = user;
+    return this.groupService.attendGroup(userId, attendGroupRequestDto);
   }
 
   @Get("/:groupId")
@@ -45,7 +47,8 @@ export class GroupController {
   }
 
   @Delete("/:groupId")
-  LeaveGroup(@Param("groupId") groupId: number, @Body() leaveGroupDto: LeaveGroupDto): Promise<string> {
-    return this.groupService.leaveGroup(groupId, leaveGroupDto);
+  LeaveGroup(@Req() { user }: CustomRequest, @Param("groupId") groupId: number): Promise<string> {
+    const { userId } = user;
+    return this.groupService.leaveGroup(userId, groupId);
   }
 }

--- a/backend/src/group/group.entity.ts
+++ b/backend/src/group/group.entity.ts
@@ -17,7 +17,7 @@ export class Group extends TimeStampEntity {
   @Column()
   groupCode: string;
 
-  @ManyToMany(() => User)
+  @ManyToMany(() => User, { cascade: true })
   @JoinTable({ name: "users_groups_TB" })
   users: User[];
 

--- a/backend/src/group/group.entity.ts
+++ b/backend/src/group/group.entity.ts
@@ -21,6 +21,6 @@ export class Group extends TimeStampEntity {
   @JoinTable({ name: "users_groups_TB" })
   users: User[];
 
-  @OneToMany(() => Album, album => album.group)
+  @OneToMany(() => Album, album => album.group, { cascade: true })
   albums: Album[];
 }

--- a/backend/src/group/group.repository.ts
+++ b/backend/src/group/group.repository.ts
@@ -3,7 +3,7 @@ import { Group } from "./group.entity";
 
 @EntityRepository(Group)
 export class GroupRepository extends Repository<Group> {
-  async readGroupQuery(groupId: number): Promise<Group> {
+  async getGroupQuery(groupId: number): Promise<Group> {
     return await this.createQueryBuilder("group")
       .leftJoin("group.users", "user")
       .select(["group.groupCode", "user.profileImage", "user.userNickname", "user.userEmail"])
@@ -17,5 +17,22 @@ export class GroupRepository extends Repository<Group> {
       .from("users_groups_TB")
       .where("groups_tb_group_id = :groupId AND users_user_id = :userId", { groupId: groupId, userId: userId })
       .execute();
+  }
+
+  async getAlbumsQuery(groupId: number): Promise<Group> {
+    return await this.createQueryBuilder("group")
+      .innerJoin("group.albums", "album")
+      .leftJoin("album.posts", "post")
+      .select([
+        "group.groupId",
+        "album.albumId",
+        "album.albumName",
+        "post.postId",
+        "post.postTitle",
+        "post.postLatitude",
+        "post.postLongitude",
+      ])
+      .where("group.groupId = :id", { id: groupId })
+      .getOne();
   }
 }

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -97,7 +97,7 @@ export class GroupService {
     const group = await this.groupRepository.readGroupQuery(groupId);
     const { users } = group;
 
-    if (!users.length) this.groupRepository.softDelete({ groupId });
+    if (!users.length) this.groupRepository.softRemove(group);
 
     return "Group leave success!!";
   }

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -39,6 +39,7 @@ export class GroupService {
     });
 
     const user = await this.userRepository.findOne(userId, { relations: ["groups"] });
+    if (!user) throw new NotFoundException(`Not found user with the id ${userId}`);
     user.groups.push(group);
     this.userRepository.save(user);
 
@@ -60,7 +61,10 @@ export class GroupService {
     const { userId, code } = attendGroupRequestDto;
 
     const group = await this.groupRepository.findOne({ groupCode: code });
+    if (!group) throw new NotFoundException(`Not found group with the code ${code}`);
+
     const user = await this.userRepository.findOne(userId, { relations: ["groups"] });
+    if (!user) throw new NotFoundException(`Not found user with the id ${userId}`);
 
     user.groups.push(group);
     this.userRepository.save(user);
@@ -80,7 +84,7 @@ export class GroupService {
     const { groupImage, groupName } = updateGroupInfoRequestDto;
 
     const group = await this.groupRepository.findOne({ groupId });
-    if (!group) throw new NotFoundException("Can not find Group");
+    if (!group) throw new NotFoundException(`Not found group with the id ${groupId}`);
 
     group.groupImage = groupImage;
     group.groupName = groupName;
@@ -96,6 +100,7 @@ export class GroupService {
     if (!result.affected) throw new NotFoundException("그룹에 해당 유저가 없습니다.");
 
     const group = await this.groupRepository.findOne(groupId, { relations: ["users", "albums"] });
+    if (!group) throw new NotFoundException(`Not found group with the id ${groupId}`);
     const { users } = group;
 
     if (!users.length) this.groupRepository.softRemove(group);

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -9,6 +9,7 @@ import { AttendGroupRequestDto } from "src/dto/group/attendGroupRequest.dto";
 import { GetGroupInfoResponseDto } from "src/dto/group/getGroupInfoResponse.dto";
 import { UpdateGroupInfoRequestDto } from "src/dto/group/updateGroupInfoRequest.dto";
 import { LeaveGroupDto } from "src/dto/group/leaveGroupRequest.dto";
+import { GetAlbumsResponseDto } from "src/dto/group/getAlbumsResponse.dto";
 
 @Injectable()
 export class GroupService {
@@ -68,7 +69,7 @@ export class GroupService {
   }
 
   async getGroupInfo(groupId: number): Promise<GetGroupInfoResponseDto> {
-    const group = await this.groupRepository.readGroupQuery(groupId);
+    const group = await this.groupRepository.getGroupQuery(groupId);
     if (!group) throw new NotFoundException(`Not found group with the id ${groupId}`);
 
     const { groupCode, users } = group;
@@ -100,5 +101,12 @@ export class GroupService {
     if (!users.length) this.groupRepository.softRemove(group);
 
     return "Group leave success!!";
+  }
+
+  async getAlbums(groupId: number): Promise<GetAlbumsResponseDto> {
+    const albumsInfo = await this.groupRepository.getAlbumsQuery(groupId);
+    if (!albumsInfo) throw new NotFoundException(`Not found group with the id ${groupId}`);
+
+    return albumsInfo;
   }
 }

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -8,7 +8,6 @@ import { CreateGroupRequestDto } from "src/dto/group/createGroupRequest.dto";
 import { AttendGroupRequestDto } from "src/dto/group/attendGroupRequest.dto";
 import { GetGroupInfoResponseDto } from "src/dto/group/getGroupInfoResponse.dto";
 import { UpdateGroupInfoRequestDto } from "src/dto/group/updateGroupInfoRequest.dto";
-import { LeaveGroupDto } from "src/dto/group/leaveGroupRequest.dto";
 import { GetAlbumsResponseDto } from "src/dto/group/getAlbumsResponse.dto";
 
 @Injectable()
@@ -22,8 +21,8 @@ export class GroupService {
     private albumRepository: AlbumRepository,
   ) {}
 
-  async createGroup(createGroupRequestDto: CreateGroupRequestDto): Promise<number> {
-    const { userId, groupImage, groupName } = createGroupRequestDto;
+  async createGroup(userId: number, createGroupRequestDto: CreateGroupRequestDto): Promise<number> {
+    const { groupImage, groupName } = createGroupRequestDto;
     const groupCode = await this.createInvitaionCode();
 
     const group = await this.groupRepository.save({
@@ -57,8 +56,8 @@ export class GroupService {
     return code;
   }
 
-  async attendGroup(attendGroupRequestDto: AttendGroupRequestDto): Promise<number> {
-    const { userId, code } = attendGroupRequestDto;
+  async attendGroup(userId: number, attendGroupRequestDto: AttendGroupRequestDto): Promise<number> {
+    const { code } = attendGroupRequestDto;
 
     const group = await this.groupRepository.findOne({ groupCode: code });
     if (!group) throw new NotFoundException(`Not found group with the code ${code}`);
@@ -93,9 +92,7 @@ export class GroupService {
     return "GroupInfo update success!!";
   }
 
-  async leaveGroup(groupId: number, leaveGroupDto: LeaveGroupDto): Promise<string> {
-    const { userId } = leaveGroupDto;
-
+  async leaveGroup(userId: number, groupId: number): Promise<string> {
     const result = await this.groupRepository.leaveGroupQuery(groupId, userId);
     if (!result.affected) throw new NotFoundException("그룹에 해당 유저가 없습니다.");
 

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -85,9 +85,7 @@ export class GroupService {
     const group = await this.groupRepository.findOne({ groupId });
     if (!group) throw new NotFoundException(`Not found group with the id ${groupId}`);
 
-    group.groupImage = groupImage;
-    group.groupName = groupName;
-    this.groupRepository.save(group);
+    this.groupRepository.update(groupId, { groupImage, groupName });
 
     return "GroupInfo update success!!";
   }

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -94,7 +94,7 @@ export class GroupService {
     const result = await this.groupRepository.leaveGroupQuery(groupId, userId);
     if (!result.affected) throw new NotFoundException("그룹에 해당 유저가 없습니다.");
 
-    const group = await this.groupRepository.readGroupQuery(groupId);
+    const group = await this.groupRepository.findOne(groupId, { relations: ["users", "albums"] });
     const { users } = group;
 
     if (!users.length) this.groupRepository.softRemove(group);

--- a/backend/src/image/service/image.service.ts
+++ b/backend/src/image/service/image.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { ImageRepository } from "../image.repository";
 import { Post } from "src/post/post.entity";
+import { Image } from "../image.entity";
 
 @Injectable()
 export class ImageService {
@@ -10,8 +11,19 @@ export class ImageService {
     private imageRepository: ImageRepository,
   ) {}
 
-  saveImage(post: Post, images: string[]): void {
-    images.forEach(e => {
+  saveImage(images: string[]): Image[] {
+    return images.map(e => {
+      const image = new Image();
+      image.imageUrl = e;
+      return image;
+    });
+  }
+
+  updateImages(post: Post, addImages: string[], deleteImagesId: number[]): void {
+    deleteImagesId.forEach(imageId => {
+      this.imageRepository.softRemove({ imageId });
+    });
+    addImages.forEach(e => {
       this.imageRepository.save({
         imageUrl: e,
         post: post,
@@ -21,7 +33,7 @@ export class ImageService {
 
   deleteImage(images: number[]): void {
     images.forEach(imageId => {
-      this.imageRepository.softDelete({ imageId });
+      this.imageRepository.softRemove({ imageId });
     });
   }
 }

--- a/backend/src/myRequest/customRequest.ts
+++ b/backend/src/myRequest/customRequest.ts
@@ -1,0 +1,3 @@
+export interface CustomRequest extends Request {
+  user: { accessToken: string; refreshToken: string; userId: number };
+}

--- a/backend/src/post/controller/post.controller.ts
+++ b/backend/src/post/controller/post.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpCode, Param, Post, Put, UseGuards } from "@nestjs/common";
+import { Body, Controller, Delete, Get, HttpCode, Param, Post, Put, UseGuards } from "@nestjs/common";
 import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
 import { PostService } from "../service/post.service";
 import { CreatePostRequestDto } from "src/dto/post/createPostRequest.dto";
@@ -27,5 +27,10 @@ export class PostController {
     @Body() updatePostInfoRequestDto: UpdatePostInfoRequestDto,
   ): Promise<string> {
     return this.postService.updatePostInfo(postId, updatePostInfoRequestDto);
+  }
+
+  @Delete("/:postId")
+  DeletePost(@Param("postId") postId: number): Promise<string> {
+    return this.postService.deletePost(postId);
   }
 }

--- a/backend/src/post/controller/post.controller.ts
+++ b/backend/src/post/controller/post.controller.ts
@@ -1,4 +1,5 @@
-import { Body, Controller, Delete, Get, HttpCode, Param, Post, Put, UseGuards } from "@nestjs/common";
+import { Body, Req, Controller, Delete, Get, HttpCode, Param, Post, Put, UseGuards } from "@nestjs/common";
+import { CustomRequest } from "src/myRequest/customRequest";
 import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
 import { PostService } from "../service/post.service";
 import { CreatePostRequestDto } from "src/dto/post/createPostRequest.dto";
@@ -12,8 +13,9 @@ export class PostController {
 
   @Post()
   @HttpCode(200)
-  CreatePost(@Body() createPostRequestDto: CreatePostRequestDto): Promise<number> {
-    return this.postService.createPost(createPostRequestDto);
+  CreatePost(@Req() { user }: CustomRequest, @Body() createPostRequestDto: CreatePostRequestDto): Promise<number> {
+    const { userId } = user;
+    return this.postService.createPost(userId, createPostRequestDto);
   }
 
   @Get("/:postId")
@@ -23,10 +25,12 @@ export class PostController {
 
   @Put("/:postId")
   UpdatePost(
+    @Req() { user }: CustomRequest,
     @Param("postId") postId: number,
     @Body() updatePostInfoRequestDto: UpdatePostInfoRequestDto,
   ): Promise<string> {
-    return this.postService.updatePostInfo(postId, updatePostInfoRequestDto);
+    const { userId } = user;
+    return this.postService.updatePostInfo(userId, postId, updatePostInfoRequestDto);
   }
 
   @Delete("/:postId")

--- a/backend/src/post/post.entity.ts
+++ b/backend/src/post/post.entity.ts
@@ -35,6 +35,6 @@ export class Post extends TimeStampEntity {
   @JoinColumn({ name: "user_id" })
   user: User;
 
-  @OneToMany(() => Image, image => image.post)
+  @OneToMany(() => Image, image => image.post, { cascade: true })
   images: Image[];
 }

--- a/backend/src/post/post.repository.ts
+++ b/backend/src/post/post.repository.ts
@@ -6,6 +6,7 @@ export class PostRepository extends Repository<Post> {
   async readPostQuery(postId: number): Promise<Post> {
     return await this.createQueryBuilder("post")
       .leftJoin("post.images", "image")
+      .leftJoin("post.user", "user")
       .select([
         "post.postTitle",
         "post.postContent",
@@ -13,6 +14,8 @@ export class PostRepository extends Repository<Post> {
         "post.postLocation",
         "image.imageUrl",
         "image.imageId",
+        "user.userId",
+        "user.userNickname",
       ])
       .where("post.postId = :id", { id: postId })
       .getOne();

--- a/backend/src/post/post.repository.ts
+++ b/backend/src/post/post.repository.ts
@@ -3,10 +3,10 @@ import { Post } from "./post.entity";
 
 @EntityRepository(Post)
 export class PostRepository extends Repository<Post> {
-  async readPostQuery(postId: number): Promise<Post> {
+  async getPostQuery(postId: number): Promise<Post> {
     return await this.createQueryBuilder("post")
-      .leftJoin("post.images", "image")
-      .leftJoin("post.user", "user")
+      .innerJoin("post.images", "image")
+      .innerJoin("post.user", "user")
       .select([
         "post.postTitle",
         "post.postContent",

--- a/backend/src/post/service/post.service.ts
+++ b/backend/src/post/service/post.service.ts
@@ -48,7 +48,8 @@ export class PostService {
   }
 
   async getPostInfo(postId: number): Promise<GetPostInfoResponseDto> {
-    const post = await this.postRepository.readPostQuery(postId);
+    const post = await this.postRepository.getPostQuery(postId);
+    if (!post) throw new NotFoundException(`Not found post with the id ${postId}`);
 
     const { user, postTitle, postContent, postDate, postLocation, images } = post;
     const userId = user.userId;
@@ -71,6 +72,7 @@ export class PostService {
     } = updatePostInfoRequestDto;
 
     const post = await this.postRepository.findOne(postId, { relations: ["user"] });
+    if (!post) throw new NotFoundException(`Not found post with the id ${postId}`);
 
     const postUserId = post.user.userId;
     if (postUserId !== userId) throw new NotFoundException("It cannot be updated because it is not the author.");

--- a/backend/src/post/service/post.service.ts
+++ b/backend/src/post/service/post.service.ts
@@ -7,6 +7,7 @@ import { AlbumRepository } from "src/album/album.repository";
 import { CreatePostRequestDto } from "src/dto/post/createPostRequest.dto";
 import { GetPostInfoResponseDto } from "src/dto/post/getPostInfoResponse.dto";
 import { UpdatePostInfoRequestDto } from "src/dto/post/updatePostInfoRequest.dto";
+import { Image } from "src/image/image.entity";
 
 @Injectable()
 export class PostService {
@@ -30,6 +31,12 @@ export class PostService {
     const album = await this.albumRepository.findOne({ albumId });
     if (!album) throw new NotFoundException(`Not found album with the id ${albumId}`);
 
+    // const images = postImages.map(e => {
+    //   const image = new Image();
+    //   image.imageUrl = e;
+    //   return image;
+    // });
+
     const post = await this.postRepository.save({
       postTitle: postTitle,
       postContent: postContent,
@@ -39,6 +46,7 @@ export class PostService {
       postLongitude: postLongitude,
       user: user,
       album: album,
+      //images: images,
     });
 
     this.imageService.saveImage(post, postImages);
@@ -89,7 +97,7 @@ export class PostService {
     const post = await this.postRepository.findOne(postId, { relations: ["images"] });
     if (!post) throw new NotFoundException(`Not found post with the id ${postId}`);
 
-    this.postRepository.softDelete({ postId });
+    this.postRepository.softRemove(post);
 
     return "Post delete success!!";
   }

--- a/backend/src/post/service/post.service.ts
+++ b/backend/src/post/service/post.service.ts
@@ -84,4 +84,13 @@ export class PostService {
 
     return "PostInfo update success!!";
   }
+
+  async deletePost(postId: number): Promise<string> {
+    const post = await this.postRepository.findOne(postId, { relations: ["images"] });
+    if (!post) throw new NotFoundException(`Not found post with the id ${postId}`);
+
+    this.postRepository.softDelete({ postId });
+
+    return "Post delete success!!";
+  }
 }

--- a/backend/src/post/service/post.service.ts
+++ b/backend/src/post/service/post.service.ts
@@ -20,8 +20,8 @@ export class PostService {
     private albumRepository: AlbumRepository,
   ) {}
 
-  async createPost(createPostRequestDto: CreatePostRequestDto): Promise<number> {
-    const { postTitle, postContent, postImages, postDate, postLocation, postLatitude, postLongitude, userId, albumId } =
+  async createPost(userId: number, createPostRequestDto: CreatePostRequestDto): Promise<number> {
+    const { postTitle, postContent, postImages, postDate, postLocation, postLatitude, postLongitude, albumId } =
       createPostRequestDto;
 
     const user = await this.userRepository.findOne({ userId });
@@ -58,18 +58,13 @@ export class PostService {
     return { userId, userNickname, postTitle, postContent, postDate, postLocation, images };
   }
 
-  async updatePostInfo(postId: number, updatePostInfoRequestDto: UpdatePostInfoRequestDto): Promise<string> {
-    const {
-      postTitle,
-      postContent,
-      deleteImagesId,
-      addImages,
-      postDate,
-      postLocation,
-      postLatitude,
-      postLongitude,
-      userId,
-    } = updatePostInfoRequestDto;
+  async updatePostInfo(
+    userId: number,
+    postId: number,
+    updatePostInfoRequestDto: UpdatePostInfoRequestDto,
+  ): Promise<string> {
+    const { postTitle, postContent, deleteImagesId, addImages, postDate, postLocation, postLatitude, postLongitude } =
+      updatePostInfoRequestDto;
 
     const post = await this.postRepository.findOne(postId, { relations: ["user"] });
     if (!post) throw new NotFoundException(`Not found post with the id ${postId}`);

--- a/backend/src/post/service/post.service.ts
+++ b/backend/src/post/service/post.service.ts
@@ -72,13 +72,7 @@ export class PostService {
     const postUserId = post.user.userId;
     if (postUserId !== userId) throw new NotFoundException("It cannot be updated because it is not the author.");
 
-    post.postTitle = postTitle;
-    post.postContent = postContent;
-    post.postDate = postDate;
-    post.postLocation = postLocation;
-    post.postLatitude = postLatitude;
-    post.postLongitude = postLongitude;
-    this.postRepository.save(post);
+    this.postRepository.update(postId, { postTitle, postContent, postDate, postLocation, postLatitude, postLongitude });
 
     this.imageService.updateImages(post, addImages, deleteImagesId);
 

--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -24,8 +24,7 @@ export class UserService {
 
   async getUserInfo(userId: number): Promise<UserInfoResponseDto> {
     const user = await this.userRepository.findOne({ userId });
-
-    if (!user) throw new NotFoundException("Can not find User");
+    if (!user) throw new NotFoundException(`Not found user with the id ${userId}`);
 
     const { profileImage, userNickname } = user;
     return { profileImage, userNickname };
@@ -34,8 +33,7 @@ export class UserService {
   async updateUserInfo(userId: number, updateUserInfoRequestDto: UpdateUserInfoRequestDto): Promise<string> {
     const { profileImage, userNickname } = updateUserInfoRequestDto;
     const user = await this.userRepository.findOne({ userId });
-
-    if (!user) throw new NotFoundException("Can not find User");
+    if (!user) throw new NotFoundException(`Not found user with the id ${userId}`);
 
     user.profileImage = profileImage;
     user.userNickname = userNickname;

--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -36,9 +36,7 @@ export class UserService {
     const user = await this.userRepository.findOne({ userId });
     if (!user) throw new NotFoundException(`Not found user with the id ${userId}`);
 
-    user.profileImage = profileImage;
-    user.userNickname = userNickname;
-    this.userRepository.save(user);
+    this.userRepository.update(userId, { profileImage, userNickname });
 
     return "UserInfo update success!!";
   }

--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -5,6 +5,7 @@ import { User } from "../user.entity";
 import { UserRepository } from "../user.repository";
 import { UserInfoResponseDto } from "src/dto/user/userInfoResponse.dto";
 import { UpdateUserInfoRequestDto } from "src/dto/user/updateUserInfoRequest.dto";
+import { UpdateResult } from "typeorm";
 
 @Injectable()
 export class UserService {
@@ -40,5 +41,9 @@ export class UserService {
     this.userRepository.save(user);
 
     return "UserInfo update success!!";
+  }
+
+  async updateToken(userId: number, refreshToken: string): Promise<UpdateResult> {
+    return this.userRepository.update(userId, { refreshToken });
   }
 }

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -21,6 +21,6 @@ export class User extends TimeStampEntity {
   @JoinTable({ name: "users_groups_TB" })
   groups: Group[];
 
-  @OneToMany(() => Post, post => post.user)
+  @OneToMany(() => Post, post => post.user, { cascade: true })
   posts: Post[];
 }

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -17,6 +17,9 @@ export class User extends TimeStampEntity {
   @Column()
   userEmail: string;
 
+  @Column()
+  refreshToken: string;
+
   @ManyToMany(() => Group)
   @JoinTable({ name: "users_groups_TB" })
   groups: Group[];

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -17,7 +17,7 @@ export class User extends TimeStampEntity {
   @Column()
   userEmail: string;
 
-  @Column()
+  @Column({ nullable: true })
   refreshToken: string;
 
   @ManyToMany(() => Group)


### PR DESCRIPTION
## 작업 내용
- 로그아웃 API
- 게시글 삭제 API
- 그룹에 있는 모든 앨범 조회 및 해당 앨범이 가지고 있는 게시글들 조회
- JWT Refresh Token 추가

## 고민한 부분
- jwt를 이용해 user를 구분할 수 있어서 userId를 받을 필요가 없어짐
  - 이러면 편하긴한데 API가 rest 스럽지 못하게 변한다.
  - 예를 들어, 1번 유저의 정보를 얻는 api는 GET요청에 `api/users/1` 이런식으로 되어있는데 userId를 받을 필요가 없으니 GET요청에 `api/users` 가 된다.
  - 이러면 1번 유저 정보가 아니라 모든 유저 정보를 가져오는 api처럼 보이게 된다.
- 결론적으로 param으로 userId를 보내야하는 api는 기존 그대로 param으로 보내 api를 rest스럽게 유지했고 body에 userId를 보내는 api는 굳이 담아 보내지 않고 jwt에서 가져다 쓰도록 수정했다.

## 리뷰 포인트
- group.repository.ts 의 getAlbumsQuery에서 Join 하는 부분

## 관련된 이슈 넘버
#122 #124 #105 #107 