### PR TITLE
게시글 삭제 구현

### DIFF
--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -40,6 +40,24 @@ interface IDispatch {
   payload: any;
 }
 
+interface IPodo {
+  content: string;
+  size: naver.maps.Size;
+  origin: naver.maps.Point;
+}
+
+interface IMarkerClustering {
+  minClusterSize: number;
+  maxZoom: number;
+  map: naver.maps.Map;
+  markers: Array<naver.maps.Marker>;
+  disableClickZoom: boolean;
+  gridSize: number;
+  icons: Array<IPodo>;
+  indexGenerator: Array<number>;
+  setMap: Function;
+}
+
 const setMap = (
   INIT_X: number,
   INIT_Y: number,
@@ -77,6 +95,7 @@ const Map = () => {
   const [clickInfo, setClickInfo] = useState<any>();
   const [naverMap, setNaverMap] = useState<naver.maps.Map>();
   const [currentMarkers, setCurrentMarkers] = useState<Array<naver.maps.Marker>>([]);
+  const [currentClustering, setCurrentClustering] = useState<IMarkerClustering | undefined>(undefined);
   const { postsList }: any = useSelector((state: RootState) => state.groups);
   const { selectedPost }: any = useSelector((state: RootState) => state.modal);
 
@@ -114,6 +133,7 @@ const Map = () => {
 
       const markerClustering = new MarkerClustering(SetClustering(naverMap as naver.maps.Map, markers));
       setCurrentMarkers(markers);
+      setCurrentClustering(markerClustering);
     };
 
     setMarker();
@@ -125,6 +145,9 @@ const Map = () => {
         marker.setVisible(false);
         marker.setMap(null);
       });
+
+      if (!currentClustering) return;
+      currentClustering.setMap(null);
     };
   }, [currentMarkers]);
 

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -75,9 +75,10 @@ const Map = () => {
   const [isRightClick, setIsRightClick] = useState<Boolean>(false);
   const [rightPosition, setRightPosition] = useState<Point>({ x: 0, y: 0 });
   const [clickInfo, setClickInfo] = useState<any>();
+  const [naverMap, setNaverMap] = useState<naver.maps.Map>();
+  const [currentMarkers, setCurrentMarkers] = useState<Array<naver.maps.Marker>>([]);
   const { postsList }: any = useSelector((state: RootState) => state.groups);
   const { selectedPost }: any = useSelector((state: RootState) => state.modal);
-  const [naverMap, setNaverMap] = useState<naver.maps.Map>();
 
   useEffect(() => {
     const initMap = () => {
@@ -113,10 +114,20 @@ const Map = () => {
       });
 
       const markerClustering = new MarkerClustering(SetClustering(naverMap as naver.maps.Map, markers));
+      setCurrentMarkers(markers);
     };
 
     setMarker();
   }, [postsList]);
+
+  useEffect(() => {
+    return () => {
+      currentMarkers.forEach((marker) => {
+        marker.setVisible(false);
+        marker.setMap(null);
+      });
+    };
+  }, [currentMarkers]);
 
   useEffect(() => {
     if (naverMap) {

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -101,7 +101,6 @@ const Map = () => {
       const handleClickMarker = (clickedPostID: number) => {
         // 아래 로직은 나중에 백엔드 API 요청을 통해 클릭한 게시글의 상세 정보를 가져온다.
         const targetPost = dummyPosts.find((post) => post.postID === clickedPostID);
-
         dispatch({ type: "SET_SELECTED_POST", payload: targetPost });
         dispatch({ type: "OPEN_MODAL", payload: "PostShowModal" });
       };

--- a/frontend/src/components/Modal/ModalManager/index.tsx
+++ b/frontend/src/components/Modal/ModalManager/index.tsx
@@ -9,6 +9,7 @@ import ThemeModal from "@components/Header/Profile/Modal/InnerModal/ThemeModal";
 import UpdateAlbumModal from "@components/Sidebar/SecondDepth/AlbumList/Header/Modal/InnerModal/UpdateAlbumModal";
 import DeleteAlbumModal from "@components/Sidebar/SecondDepth/AlbumList/Header/Modal/InnerModal/DeleteAlbumModal";
 import AddGroupModal from "@components/Sidebar/FirstDepth/AddGroupButton/Modal/";
+import PostDeleteModal from "@components/Modal/PostDeleteModal";
 import { useSelector } from "react-redux";
 import { RootState } from "@src/reducer";
 import CloseModal from "../CloseModal";
@@ -33,6 +34,7 @@ const ModalManager = ({ setIsToggle }: ModalManagerProps) => {
       {nowModal === "UpdateAlbumModal" && <UpdateAlbumModal />}
       {nowModal === "DeleteAlbumModal" && <DeleteAlbumModal />}
       {nowModal === "AddGroupModal" && <AddGroupModal />}
+      {nowModal === "PostDeleteModal" && <PostDeleteModal />}
     </>
   );
 };

--- a/frontend/src/components/Modal/PostDeleteModal/index.tsx
+++ b/frontend/src/components/Modal/PostDeleteModal/index.tsx
@@ -1,0 +1,146 @@
+import Modal from "@components/Modal";
+import styled, { keyframes } from "styled-components";
+import { flexRowCenterAlign } from "@styles/StyledComponents";
+import COLOR from "@styles/Color";
+import { useSelector } from "react-redux";
+import { RootState } from "@src/reducer";
+import { useDispatch } from "react-redux";
+
+const PostDeleteModal = () => {
+  const dispatch = useDispatch();
+  const { selectedPost }: any = useSelector((state: RootState) => state.modal);
+  const { selectedGroup, albumList }: any = useSelector((state: RootState) => state.groups);
+
+  const closeModal = () => {
+    dispatch({ type: "CLOSE_MODAL" });
+  };
+
+  const onClickDeleteBtn = () => {
+    dispatch({ type: "DELETE_POST", payload: selectedPost });
+    dispatch({
+      type: "SET_SELECTED_GROUP",
+      payload: {
+        groupID: selectedGroup.groupID,
+        groupName: selectedGroup.groupName,
+        groupImg: selectedGroup.groupImg,
+        albumList: albumList,
+      },
+    });
+    closeModal();
+  };
+
+  return (
+    <Modal>
+      <ModalContainer
+        onClick={(event) => {
+          event.nativeEvent.stopImmediatePropagation();
+        }}
+      >
+        <Header>
+          <CloseBtn>
+            <button type="button" onClick={closeModal}>
+              <img src="/icons/clear.svg" alt="clear icon" />
+            </button>
+          </CloseBtn>
+          <Title>삭제 확인</Title>
+          <Content>
+            <DeleteAlbumGuideWrapper>
+              "{selectedPost.postTitle}" 게시글을 정말 삭제하시겠습니까?
+            </DeleteAlbumGuideWrapper>
+            <BtnWrapper>
+              <CancelBtnWrapper onClick={closeModal}>취소</CancelBtnWrapper>
+              <DeleteBtnWrapper onClick={onClickDeleteBtn}>삭제</DeleteBtnWrapper>
+            </BtnWrapper>
+          </Content>
+        </Header>
+      </ModalContainer>
+    </Modal>
+  );
+};
+
+const modalSlideUp = keyframes`
+  0% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  30% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+const ModalContainer = styled.div`
+  background-color: ${COLOR.WHITE};
+  min-height: 35vh;
+  min-width: 30vw;
+  border-radius: 50px;
+  display: flex;
+  flex-direction: column;
+  animation-name: ${modalSlideUp};
+  animation-duration: 1s;
+`;
+const Header = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+const CloseBtn = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  margin-top: 30px;
+  margin-right: 30px;
+
+  & > button {
+    background-color: ${COLOR.WHITE};
+    border: none;
+  }
+`;
+const Title = styled.div`
+  font-size: 40px;
+`;
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 2rem;
+`;
+const DeleteAlbumGuideWrapper = styled.div`
+  width: 100%;
+  margin-top: 30px;
+  font-size: 1.5rem;
+  text-align: center;
+`;
+
+const BtnWrapper = styled.div`
+  display: grid;
+  grid-template-columns: 40% 20% 40%;
+`;
+const CancelBtnWrapper = styled.div`
+  ${flexRowCenterAlign}
+  width: 8rem;
+  height: 39px;
+  border-radius: 10px;
+  border: 1px solid ${COLOR.BLUE};
+  color: ${COLOR.BLACK};
+  background-color: ${COLOR.WHITE};
+  margin-top: 50px;
+  font-size: 30px;
+  grid-column-start: 1;
+  grid-column-end: 2;
+  cursor: pointer;
+`;
+const DeleteBtnWrapper = styled.div`
+  ${flexRowCenterAlign}
+  width: 8rem;
+  height: 39px;
+  border-radius: 10px;
+  color: ${COLOR.WHITE};
+  background-color: ${COLOR.RED};
+  margin-top: 50px;
+  font-size: 30px;
+  grid-column-start: 3;
+  grid-column-end: 4;
+  cursor: pointer;
+`;
+export default PostDeleteModal;

--- a/frontend/src/components/Modal/PostShowModal/Modal/index.tsx
+++ b/frontend/src/components/Modal/PostShowModal/Modal/index.tsx
@@ -1,11 +1,15 @@
 import styled from "styled-components";
 import { flexRowCenterAlign } from "@src/styles/StyledComponents";
 import COLOR from "@src/styles/Color";
-
+import { useDispatch } from "react-redux";
 const PostSettingModal = () => {
+  const dispatch = useDispatch();
+
   const onClickUpdatePost = () => {};
 
-  const onClickDeletePost = () => {};
+  const onClickDeletePost = () => {
+    dispatch({ type: "OPEN_MODAL", payload: "PostDeleteModal" });
+  };
 
   return (
     <ModalWrapper>

--- a/frontend/src/reducer/GroupReducer.ts
+++ b/frontend/src/reducer/GroupReducer.ts
@@ -80,6 +80,20 @@ const groupReducer = (state = initState, action: any) => {
         ...state,
         albumList: newAlbumList,
       };
+    case "DELETE_POST":
+      const targetPost = action.payload;
+      const targetAlbum = state.albumList.find((album) => {
+        const found = album.posts.find((innerPost) => innerPost.postID === targetPost.postID);
+        if (found) return true;
+      });
+
+      if (!targetAlbum) return { ...state };
+
+      targetAlbum.posts = targetAlbum.posts.filter((innerPost) => innerPost.postID !== targetPost.postID);
+
+      return {
+        ...state,
+      };
     // case GroupAction.SET_ALL_GROUPS:
     //   return {
     //     ...state,


### PR DESCRIPTION
## 작업 내용
### 게시글 삭제 구현
![video2](https://user-images.githubusercontent.com/50266862/141688290-d306126c-4696-4ba7-aafb-2f2d7affafa2.gif)

- 새로운 그룹 클릭 시 기존 마커 제거
- 그룹 삭제 후, 제거된 마커와 클러스터 현재 게시글들을 바탕으로 동기화시킴(기존 마커들, 클러스터 지우고 새로 만듬)

## 고민한 부분
- 기존의 마커와 클러스터를 어떻게 지울 지 고민했음.
- reducer에서 제거된 후의 `albumList`를 어떻게 갱신할 지 고민했음.

## 리뷰 포인트
reducer에서 게시글을 삭제하는 로직

## 관련된 이슈 넘버
#72 