### PR TITLE
잘못된 URL 입력시 예외 페이지로 라우팅 구현

### DIFF
--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Switch, Route } from "react-router-dom";
 
 import Login from "@pages/Login";
 import Main from "@pages/Main";
+import NotFound from "@pages/NotFound";
 
 export const Router: React.FC = () => {
   return (
@@ -10,6 +11,7 @@ export const Router: React.FC = () => {
       <Switch>
         <Route path="/login" exact component={() => <Login />}></Route>
         <Route path="/" exact component={() => <Main />}></Route>
+        <Route component={NotFound}></Route>
       </Switch>
     </BrowserRouter>
   );

--- a/frontend/src/pages/NotFound/index.tsx
+++ b/frontend/src/pages/NotFound/index.tsx
@@ -1,0 +1,33 @@
+import styled from "styled-components";
+
+const NotFound = () => {
+  return (
+    <NotFoundWrapper>
+      <ImageWrapper>
+        <Guide>잘못된 페이지에요 ㅠㅠ</Guide>
+      </ImageWrapper>
+    </NotFoundWrapper>
+  );
+};
+
+const NotFoundWrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
+`;
+const ImageWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  background: center;
+  background-image: url("/icons/crying-podo.png");
+  background-size: 40%;
+  background-repeat: no-repeat;
+  width: 100%;
+  height: 95vh;
+`;
+const Guide = styled.div`
+  font-size: 5rem;
+  margin-bottom: 1vh;
+`;
+
+export default NotFound;


### PR DESCRIPTION
## 작업 내용
### `/`, `/login` 말고 다른 URL은 아래와 같은 페이지를 렌더링하도록 구현
![video5](https://user-images.githubusercontent.com/50266862/141999334-067a1574-316b-45be-8c29-990c66997ef6.gif)


## 고민한 부분


## 리뷰 포인트
다음 사항을 `<Route />` 컴포넌트들을 위에서 아래로 하나씩 확인한다.
> URL이 `path`라는 정규식에 매칭이 되는지, 또한 `exact`가 켜져 있어 정확히 일치한지를 확인한다. 로그인과 메인이 둘 다 해당 안되면, 맨 아래 `<NotFound />`를 그려준다.

## 관련된 이슈 넘버
#133 