### PR TITLE
사이드바 순서 API 및 앨범 삭제 CASCADE 제거

### DIFF
--- a/backend/src/album/album.entity.ts
+++ b/backend/src/album/album.entity.ts
@@ -18,6 +18,6 @@ export class Album extends TimeStampEntity {
   @JoinColumn({ name: "group_id" })
   group: Group;
 
-  @OneToMany(() => Post, post => post.album, { cascade: true })
+  @OneToMany(() => Post, post => post.album)
   posts: Post[];
 }

--- a/backend/src/album/album.module.ts
+++ b/backend/src/album/album.module.ts
@@ -5,10 +5,11 @@ import { AlbumController } from "./controller/album.controller";
 import { AlbumService } from "./service/album.service";
 import { AlbumRepository } from "./album.repository";
 import { GroupRepository } from "src/group/group.repository";
+import { PostRepository } from "src/post/post.repository";
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([AlbumRepository, GroupRepository]),
+    TypeOrmModule.forFeature([AlbumRepository, GroupRepository, PostRepository]),
     JwtModule.register({
       secret: process.env.JWT_SECRET,
     }),

--- a/backend/src/album/album.repository.ts
+++ b/backend/src/album/album.repository.ts
@@ -2,4 +2,12 @@ import { EntityRepository, Repository } from "typeorm";
 import { Album } from "./album.entity";
 
 @EntityRepository(Album)
-export class AlbumRepository extends Repository<Album> {}
+export class AlbumRepository extends Repository<Album> {
+  async getDeletePostIdQuery(albumId: number): Promise<Album> {
+    return await this.createQueryBuilder("album")
+      .leftJoin("album.posts", "post")
+      .select(["album.albumId", "post.postId"])
+      .where("album.albumId = :id", { id: albumId })
+      .getOne();
+  }
+}

--- a/backend/src/album/controller/album.controller.ts
+++ b/backend/src/album/controller/album.controller.ts
@@ -4,6 +4,7 @@ import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
 import { AlbumService } from "../service/album.service";
 import { CreateAlbumRequestDto } from "src/dto/album/createAlbumRequest.dto";
 import { UpdateAlbumInfoRequestDto } from "src/dto/album/updateAlbumInfoRequest.dto";
+import { DeleteAlbumRequestDto } from "src/dto/album/deleteAlbumRequest.dto";
 
 @ApiTags("앨범 API")
 @ApiBearerAuth()
@@ -33,7 +34,10 @@ export class AlbumController {
   @Delete("/:albumId")
   @HttpCode(200)
   @ApiOkResponse({ description: "앨범 삭제 성공" })
-  DeleteAlbum(@Param("albumId") albumId: number): Promise<string> {
-    return this.albumService.deleteAlbum(albumId);
+  DeleteAlbum(
+    @Param("albumId") albumId: number,
+    @Body() deleteAlbumRequestDto: DeleteAlbumRequestDto,
+  ): Promise<string> {
+    return this.albumService.deleteAlbum(albumId, deleteAlbumRequestDto);
   }
 }

--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -53,13 +53,7 @@ export class AlbumService {
 
     if (albumId === baseAlbum.albumId) throw new NotFoundException("It cannot be deleted because it is baseAlbum.");
 
-    const { posts } = await this.getMovePosts(albumId);
-    console.log(posts);
-    posts.forEach(post => {
-      const postId = post.postId;
-      this.postRepository.update(postId, { album: baseAlbum });
-    });
-
+    await this.movePosts(albumId, baseAlbum);
     this.albumRepository.softRemove(album);
 
     return "Album delete success!!";
@@ -70,6 +64,15 @@ export class AlbumService {
     const baseAlbumId = albums[0];
 
     return baseAlbumId;
+  }
+
+  async movePosts(albumId: number, baseAlbum: Album): Promise<void> {
+    const { posts } = await this.getMovePosts(albumId);
+
+    posts.forEach(post => {
+      const postId = post.postId;
+      this.postRepository.update(postId, { album: baseAlbum });
+    });
   }
 
   async getMovePosts(albumId: number): Promise<Album> {

--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -28,7 +28,10 @@ export class AuthController {
 
     res.cookie("accessToken", accessToken, { maxAge: oneHour });
     res.cookie("refreshToken", refreshToken, { maxAge: oneWeek });
-    res.redirect("/");
+
+    const redirectUrl = process.env.NODE_ENV === "dev" ? process.env.DEV_REDIRECT_URL : process.env.PROD_REDIRECT_URL;
+
+    res.redirect(redirectUrl);
   }
 
   @Post("/logout")

--- a/backend/src/dto/album/deleteAlbumRequest.dto.ts
+++ b/backend/src/dto/album/deleteAlbumRequest.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsNumber } from "class-validator";
+
+export class DeleteAlbumRequestDto {
+  @IsNumber()
+  @IsNotEmpty()
+  @ApiProperty()
+  groupId: number;
+}

--- a/backend/src/dto/group/updateAlbumOrderRequest.dto.ts
+++ b/backend/src/dto/group/updateAlbumOrderRequest.dto.ts
@@ -1,0 +1,9 @@
+import { IsString, IsOptional } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class UpdateAlbumOrderRequestDto {
+  @IsString()
+  @IsOptional()
+  @ApiProperty()
+  albumOrder: string;
+}

--- a/backend/src/dto/post/shiftPostRequest.dto.ts
+++ b/backend/src/dto/post/shiftPostRequest.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, IsNumber } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class ShiftPostRequestDto {
+  @IsNumber()
+  @IsNotEmpty()
+  @ApiProperty()
+  albumId: number;
+}

--- a/backend/src/dto/user/updateGroupOrderRequest.dto.ts
+++ b/backend/src/dto/user/updateGroupOrderRequest.dto.ts
@@ -1,0 +1,9 @@
+import { IsString, IsNotEmpty } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class UpdateGroupOrderRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty()
+  groupOrder: string;
+}

--- a/backend/src/group/controller/group.controller.ts
+++ b/backend/src/group/controller/group.controller.ts
@@ -8,6 +8,7 @@ import { AttendGroupRequestDto } from "src/dto/group/attendGroupRequest.dto";
 import { GetGroupInfoResponseDto } from "src/dto/group/getGroupInfoResponse.dto";
 import { UpdateGroupInfoRequestDto } from "src/dto/group/updateGroupInfoRequest.dto";
 import { GetAlbumsResponseDto } from "src/dto/group/getAlbumsResponse.dto";
+import { UpdateAlbumOrderRequestDto } from "src/dto/group/updateAlbumOrderRequest.dto";
 
 @ApiTags("그룹 API")
 @ApiBearerAuth()
@@ -63,5 +64,16 @@ export class GroupController {
   LeaveGroup(@Req() { user }: CustomRequest, @Param("groupId") groupId: number): Promise<string> {
     const { userId } = user;
     return this.groupService.leaveGroup(userId, groupId);
+  }
+
+  @Put("/:groupId/albumorder")
+  @HttpCode(200)
+  @ApiParam({ name: "groupId", type: Number })
+  @ApiOkResponse({ description: "앨범 순서 수정 성공" })
+  UpdateAlbumOrder(
+    @Param("groupId") groupId: number,
+    @Body() updateAlbumOrderRequestDto: UpdateAlbumOrderRequestDto,
+  ): Promise<string> {
+    return this.groupService.updateAlbumOrder(groupId, updateAlbumOrderRequestDto);
   }
 }

--- a/backend/src/group/group.entity.ts
+++ b/backend/src/group/group.entity.ts
@@ -17,6 +17,9 @@ export class Group extends TimeStampEntity {
   @Column()
   groupCode: string;
 
+  @Column()
+  albumOrder: string;
+
   @ManyToMany(() => User, { cascade: true })
   @JoinTable({ name: "users_groups_TB" })
   users: User[];

--- a/backend/src/group/group.repository.ts
+++ b/backend/src/group/group.repository.ts
@@ -35,4 +35,13 @@ export class GroupRepository extends Repository<Group> {
       .where("group.groupId = :id", { id: groupId })
       .getOne();
   }
+
+  async getBaseAlbumQuery(groupId: number): Promise<Group> {
+    const base = true;
+    return await this.createQueryBuilder("group")
+      .innerJoin("group.albums", "album")
+      .select(["group.groupId", "album.albumId"])
+      .where("group.groupId = :id AND album.base = :base", { id: groupId, base: base })
+      .getOne();
+  }
 }

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -9,6 +9,7 @@ import { AttendGroupRequestDto } from "src/dto/group/attendGroupRequest.dto";
 import { GetGroupInfoResponseDto } from "src/dto/group/getGroupInfoResponse.dto";
 import { UpdateGroupInfoRequestDto } from "src/dto/group/updateGroupInfoRequest.dto";
 import { GetAlbumsResponseDto } from "src/dto/group/getAlbumsResponse.dto";
+import { UpdateAlbumOrderRequestDto } from "src/dto/group/updateAlbumOrderRequest.dto";
 
 @Injectable()
 export class GroupService {
@@ -108,5 +109,12 @@ export class GroupService {
     if (!albumsInfo) throw new NotFoundException(`Not found group with the id ${groupId}`);
 
     return albumsInfo;
+  }
+
+  async updateAlbumOrder(groupId: number, updateAlbumOrderRequestDto: UpdateAlbumOrderRequestDto): Promise<string> {
+    const { albumOrder } = updateAlbumOrderRequestDto;
+    this.groupRepository.update(groupId, { albumOrder });
+
+    return "Album Order update success!!";
   }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -4,9 +4,20 @@ import { NestFactory } from "@nestjs/core";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { AppModule } from "./app.module";
 
+const options = {
+  origin: ["http://localhost:3000", "http://localhost:5000", "http://118.67.131.142:5000"],
+  methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
+  preflightContinue: false,
+  optionsSuccessStatus: 204,
+  credentials: true,
+};
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.use(cookieParser());
+
+  app.enableCors();
+
+  app.use(cookieParser(options));
 
   app.useGlobalPipes(
     new ValidationPipe({
@@ -29,6 +40,7 @@ async function bootstrap() {
       "accessToken",
     )
     .build();
+
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup("api", app, document);
 

--- a/backend/src/post/controller/post.controller.ts
+++ b/backend/src/post/controller/post.controller.ts
@@ -19,6 +19,7 @@ import { PostService } from "../service/post.service";
 import { CreatePostRequestDto } from "src/dto/post/createPostRequest.dto";
 import { GetPostInfoResponseDto } from "src/dto/post/getPostInfoResponse.dto";
 import { UpdatePostInfoRequestDto } from "src/dto/post/updatePostInfoRequest.dto";
+import { ShiftPostRequestDto } from "src/dto/post/shiftPostRequest.dto";
 import { FilesInterceptor } from "@nestjs/platform-express";
 import { multerOption } from "src/image/service/image.service";
 
@@ -70,5 +71,12 @@ export class PostController {
   @ApiOkResponse({ description: "게시글 삭제 성공" })
   DeletePost(@Param("postId") postId: number): Promise<string> {
     return this.postService.deletePost(postId);
+  }
+
+  @Put("/:postId/shift")
+  @ApiParam({ name: "postId", type: Number })
+  @ApiOkResponse({ description: "게시글 이동 성공" })
+  ShiftPost(@Param("postId") postId: number, @Body() shiftPostRequestDto: ShiftPostRequestDto): Promise<string> {
+    return this.postService.shiftPost(postId, shiftPostRequestDto);
   }
 }

--- a/backend/src/post/post.entity.ts
+++ b/backend/src/post/post.entity.ts
@@ -27,7 +27,7 @@ export class Post extends TimeStampEntity {
   @Column({ type: "decimal", precision: 18, scale: 10 })
   postLongitude: number;
 
-  @ManyToOne(() => Album, album => album.posts, { onDelete: "CASCADE" })
+  @ManyToOne(() => Album, album => album.posts)
   @JoinColumn({ name: "album_id" })
   album: Album;
 

--- a/backend/src/post/service/post.service.ts
+++ b/backend/src/post/service/post.service.ts
@@ -7,6 +7,7 @@ import { AlbumRepository } from "src/album/album.repository";
 import { CreatePostRequestDto } from "src/dto/post/createPostRequest.dto";
 import { GetPostInfoResponseDto } from "src/dto/post/getPostInfoResponse.dto";
 import { UpdatePostInfoRequestDto } from "src/dto/post/updatePostInfoRequest.dto";
+import { ShiftPostRequestDto } from "src/dto/post/shiftPostRequest.dto";
 
 @Injectable()
 export class PostService {
@@ -93,5 +94,15 @@ export class PostService {
     this.postRepository.softRemove(post);
 
     return "Post delete success!!";
+  }
+
+  async shiftPost(postId: number, shiftPostRequestDto: ShiftPostRequestDto): Promise<string> {
+    const { albumId } = shiftPostRequestDto;
+    const album = await this.albumRepository.findOne(albumId);
+    if (!album) throw new NotFoundException(`Not found album with the id ${albumId}`);
+
+    this.postRepository.update(postId, { album });
+
+    return "Post Shift success!!";
   }
 }

--- a/backend/src/user/controller/user.controller.ts
+++ b/backend/src/user/controller/user.controller.ts
@@ -5,6 +5,7 @@ import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
 import { UserService } from "../service/user.service";
 import { UserInfoResponseDto } from "src/dto/user/userInfoResponse.dto";
 import { UpdateUserInfoRequestDto } from "src/dto/user/updateUserInfoRequest.dto";
+import { UpdateGroupOrderRequestDto } from "src/dto/user/updateGroupOrderRequest.dto";
 
 @ApiTags("유저 API")
 @ApiBearerAuth()
@@ -29,5 +30,16 @@ export class UserController {
   ): Promise<string> {
     const { userId } = user;
     return this.userService.updateUserInfo(userId, updateUserInfoRequestDto);
+  }
+
+  @Put("/grouporder")
+  @HttpCode(200)
+  @ApiOkResponse({ description: "그룹 순서 수정 성공" })
+  UpdateGroupOrder(
+    @Req() { user }: CustomRequest,
+    @Body() updateGroupOrderRequestDto: UpdateGroupOrderRequestDto,
+  ): Promise<string> {
+    const { userId } = user;
+    return this.userService.updateGroupOrder(userId, updateGroupOrderRequestDto);
   }
 }

--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -5,6 +5,7 @@ import { User } from "../user.entity";
 import { UserRepository } from "../user.repository";
 import { UserInfoResponseDto } from "src/dto/user/userInfoResponse.dto";
 import { UpdateUserInfoRequestDto } from "src/dto/user/updateUserInfoRequest.dto";
+import { UpdateGroupOrderRequestDto } from "src/dto/user/updateGroupOrderRequest.dto";
 import { UpdateResult } from "typeorm";
 
 @Injectable()
@@ -43,5 +44,12 @@ export class UserService {
 
   async updateToken(userId: number, refreshToken: string): Promise<UpdateResult> {
     return this.userRepository.update(userId, { refreshToken });
+  }
+
+  async updateGroupOrder(userId: number, updateGroupOrderRequestDto: UpdateGroupOrderRequestDto): Promise<string> {
+    const { groupOrder } = updateGroupOrderRequestDto;
+    this.userRepository.update(userId, { groupOrder });
+
+    return "GroupOrder update success!!";
   }
 }

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -18,6 +18,9 @@ export class User extends TimeStampEntity {
   userEmail: string;
 
   @Column({ nullable: true })
+  groupOrder: string;
+
+  @Column({ nullable: true })
   refreshToken: string;
 
   @ManyToMany(() => Group)


### PR DESCRIPTION
## 작업 내용
- 그룹 & 앨범 순서 수정 API 구현
  - user, group에 order 컬럼을 추가해 순서 저장
- 앨범 간 게시글 이동 API 구현
- 앨범 삭제시 CASCADE 제거
  - 앨범 삭제시 포함된 게시글들은 기본 앨범으로 이동

## 고민한 부분
- 오늘 PR에는 없는 부분이지만 그룹 & 앨범 순서를 보고 조회시 순서를 보장해줘야하는데 순서 인덱스 크기만큼 쿼리를 날려서 하나씩 조회해 배열에 넣어줘야해서 조금 비효율적인 것 같다... 해결할 방법이 없을까?? 떠오르지 않는다..

## 리뷰 포인트
오늘은 작업을 많이 못했네요 ㅠㅠ 내일은 열심히 달려보겠습니다!

## 관련된 이슈 넘버
#144 #145 #148 