### PR TITLE
Feat: 앨범 생성 API 연결

### DIFF
--- a/frontend/src/components/Sidebar/SecondDepth/AddAlbum/InputModal/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AddAlbum/InputModal/index.tsx
@@ -1,11 +1,11 @@
-import { useRef, Dispatch, SetStateAction } from "react";
+import { useRef, Dispatch, SetStateAction, useState, ChangeEvent, useEffect } from "react";
 import styled, { keyframes } from "styled-components";
 import { flexRowCenterAlign } from "@styles/StyledComponents";
 import COLOR from "@styles/Color";
 import { useSelector } from "react-redux";
 import { RootState } from "@src/reducer";
 import { useDispatch } from "react-redux";
-import { GroupAction } from "@src/action";
+import { newAlbumRequestAction } from "@src/reducer/AlbumReducer";
 
 interface InputModalProps {
   addAlbumModalRef: React.RefObject<HTMLDivElement>;
@@ -13,34 +13,34 @@ interface InputModalProps {
 }
 
 const InputModal = ({ addAlbumModalRef, setIsAddAlbumModalOpened }: InputModalProps) => {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const { groups, selectedGroup }: any = useSelector((state: RootState) => state.groups);
+  const [albumName, setAlbumName] = useState("");
+  const [addAlbum, setAddAlbum] = useState(true);
+  const { selectedGroup }: any = useSelector((state: RootState) => state.groups);
   const dispatch = useDispatch();
 
+  useEffect(() => {
+    if (addAlbum) {
+      setAlbumName("");
+    }
+  }, [addAlbum]);
+
   const onClickAddAlbum = () => {
-    console.log("로직 수정 예정");
-    // if (!inputRef.current) return;
+    if (!albumName) return;
+    const selectedGroupId = selectedGroup.groupID;
 
-    // const albumName = inputRef.current.value;
-    // const selectedGroupID = selectedGroup.groupID;
-    // const selectedAlbumList = groups[selectedGroupID].albumList;
-    // const albumID = selectedAlbumList[selectedAlbumList.length - 1].albumID + 1;
-
-    // const newAlbum = {
-    //   albumID,
-    //   albumName,
-    //   posts: [],
-    // };
-
-    // selectedAlbumList.push(newAlbum);
-
-    // dispatch({ type: GroupAction.SET_ALL_GROUPS, payload: groups });
+    dispatch(newAlbumRequestAction(albumName, selectedGroupId));
+    setAddAlbum(true);
     setIsAddAlbumModalOpened(false);
+  };
+
+  const onChangeName = (e: ChangeEvent<HTMLInputElement>) => {
+    setAlbumName(e.target.value);
+    setAddAlbum(false);
   };
 
   return (
     <AddAlbumModalWrapper ref={addAlbumModalRef} className="add-album-modal">
-      <AlbumCreateInputWrapper placeholder="새 앨범" ref={inputRef} />
+      <AlbumCreateInputWrapper placeholder="새 앨범" onChange={onChangeName} />
       <AlbumCreateBtnWrapper onClick={onClickAddAlbum}>생성</AlbumCreateBtnWrapper>
     </AddAlbumModalWrapper>
   );
@@ -99,7 +99,13 @@ const AlbumCreateBtnWrapper = styled.div`
   background-color: ${(props) => props.theme.SECONDARY};
   color: ${COLOR.WHITE};
   border-radius: 10px;
-  cursor: pointer;
+  &:hover {
+    cursor: pointer;
+    background-color: ${(props) => props.theme.PRIMARY};
+  }
+  &:active {
+    font-weight: bold;
+  }
 `;
 
 export default InputModal;

--- a/frontend/src/reducer/AlbumReducer.ts
+++ b/frontend/src/reducer/AlbumReducer.ts
@@ -1,0 +1,50 @@
+export const initState = {
+  newAlbumLoading: false,
+  newAlbumSucceed: false,
+  newAlbumError: false,
+};
+
+// action
+export const NEW_ALBUM_REQUEST = "NEW_ALBUM_REQUEST";
+export const NEW_ALBUM_SUCCEED = "NEW_ALBUM_SUCCEED";
+export const NEW_ALBUM_FAILED = "NEW_ALBUM_FAILED";
+
+//action creator
+export const newAlbumRequestAction = (albumName: string, groupId: number) => ({
+  type: NEW_ALBUM_REQUEST,
+  payload: {
+    albumName,
+    groupId,
+  },
+});
+
+// reducer
+export const albumReducer = (state = initState, action: any) => {
+  switch (action.type) {
+    case NEW_ALBUM_REQUEST:
+      return {
+        ...state,
+        newAlbumLoading: true,
+        newAlbumSucceed: false,
+        newAlbumError: false,
+      };
+    case NEW_ALBUM_SUCCEED:
+      return {
+        ...state,
+        newAlbumLoading: false,
+        newAlbumSucceed: true,
+        newAlbumError: false,
+      };
+    case NEW_ALBUM_FAILED:
+      return {
+        ...state,
+        newAlbumLoading: false,
+        newAlbumSucceed: false,
+        newAlbumError: true,
+      };
+    default:
+      return state;
+  }
+};
+
+export default albumReducer;

--- a/frontend/src/reducer/index.ts
+++ b/frontend/src/reducer/index.ts
@@ -5,6 +5,7 @@ import ModalReducer from "./Modal";
 import AddressReducer from "./AddressReducer";
 import Theme from "./Theme";
 import UserReducer from "./UserReducer";
+import AlbumReducer from "./AlbumReducer";
 
 const rootReducer = combineReducers({
   groupModal: GroupModalReducer,
@@ -13,6 +14,7 @@ const rootReducer = combineReducers({
   theme: Theme,
   address: AddressReducer,
   user: UserReducer,
+  album: AlbumReducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/frontend/src/sagas/album.ts
+++ b/frontend/src/sagas/album.ts
@@ -1,0 +1,27 @@
+import { all, fork, put, call, takeLatest } from "redux-saga/effects";
+import { NEW_ALBUM_REQUEST, NEW_ALBUM_SUCCEED, NEW_ALBUM_FAILED } from "@src/reducer/AlbumReducer";
+import axios from "axios";
+
+const SERVER_URL = process.env.REACT_APP_SERVER_URL;
+
+function createAlbumApi(albumName: string, groupId: number) {
+  return axios.post(`${SERVER_URL}/api/albums`, { albumName, groupId }, { withCredentials: true });
+}
+
+function* createAlbum({ payload }: any) {
+  try {
+    const { albumName, groupId } = payload;
+    yield call(createAlbumApi, albumName, groupId);
+    yield put({ type: NEW_ALBUM_SUCCEED });
+  } catch (err: any) {
+    yield put({ type: NEW_ALBUM_FAILED });
+  }
+}
+
+function* watchAlbumCreate() {
+  yield takeLatest(NEW_ALBUM_REQUEST, createAlbum);
+}
+
+export default function* albumSaga() {
+  yield all([fork(watchAlbumCreate)]);
+}

--- a/frontend/src/sagas/index.tsx
+++ b/frontend/src/sagas/index.tsx
@@ -1,7 +1,8 @@
-import { all, call, fork } from "redux-saga/effects";
+import { all, fork } from "redux-saga/effects";
 import group from "./group";
 import user from "./user";
+import album from "./album";
 
 export default function* rootSaga() {
-  yield all([fork(group), fork(user)]);
+  yield all([fork(group), fork(user), fork(album)]);
 }


### PR DESCRIPTION
## 작업 내용
![album_add](https://user-images.githubusercontent.com/48939876/142233384-ccbc4390-fa60-4237-8a77-d263fcf09bcb.gif)
add album 버튼을 누르고 새 앨범을 추가

## 고민한 부분
앨범 리스트 조회를 하려면 그룹에서 조회해야하는데 건드리면 merge conflict가 어마무시할 것 같아 일단 생성하는 로직만 추가해놨습니다.
프론트에서 확인을 할 수 없어 mySQL화면과 함께 했습니다.
관련해서 수정까지 코드를 짰지만 albumId를 알 수 없어 일단 스태시에 옮겨놨습니다.

확인 버튼을 눌러 생성 시 해당 모달이 close 되므로 이와 함께 albumName도 초기화했습니다.

## 리뷰 포인트
감사합니다.

## 관련된 이슈 넘버
#159