### PR TITLE
해시태그 생성 및 기존 API 수정

### DIFF
--- a/backend/src/album/controller/album.controller.ts
+++ b/backend/src/album/controller/album.controller.ts
@@ -4,7 +4,6 @@ import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
 import { AlbumService } from "../service/album.service";
 import { CreateAlbumRequestDto } from "src/dto/album/createAlbumRequest.dto";
 import { UpdateAlbumInfoRequestDto } from "src/dto/album/updateAlbumInfoRequest.dto";
-import { DeleteAlbumRequestDto } from "src/dto/album/deleteAlbumRequest.dto";
 
 @ApiTags("앨범 API")
 @ApiBearerAuth()
@@ -33,11 +32,9 @@ export class AlbumController {
 
   @Delete("/:albumId")
   @HttpCode(200)
+  @ApiParam({ name: "albumId", type: Number })
   @ApiOkResponse({ description: "앨범 삭제 성공" })
-  DeleteAlbum(
-    @Param("albumId") albumId: number,
-    @Body() deleteAlbumRequestDto: DeleteAlbumRequestDto,
-  ): Promise<string> {
-    return this.albumService.deleteAlbum(albumId, deleteAlbumRequestDto);
+  DeleteAlbum(@Param("albumId") albumId: number): Promise<string> {
+    return this.albumService.deleteAlbum(albumId);
   }
 }

--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -4,7 +4,6 @@ import { AlbumRepository } from "../album.repository";
 import { GroupRepository } from "src/group/group.repository";
 import { CreateAlbumRequestDto } from "src/dto/album/createAlbumRequest.dto";
 import { UpdateAlbumInfoRequestDto } from "src/dto/album/updateAlbumInfoRequest.dto";
-import { DeleteAlbumRequestDto } from "src/dto/album/deleteAlbumRequest.dto";
 import { Album } from "../album.entity";
 import { PostRepository } from "src/post/post.repository";
 
@@ -47,17 +46,17 @@ export class AlbumService {
     return "AlbumInfo update success!!";
   }
 
-  async deleteAlbum(albumId: number, deleteAlbumRequestDto: DeleteAlbumRequestDto): Promise<string> {
-    const { groupId } = deleteAlbumRequestDto;
-
+  async deleteAlbum(albumId: number): Promise<string> {
     const album = await this.albumRepository.findOne({ albumId });
     if (!album) throw new NotFoundException(`Not found album with the id ${albumId}`);
 
+    const { base, group } = album;
+    if (base) throw new NotFoundException("It cannot be deleted because it is baseAlbum.");
+
+    const { groupId } = group;
     const baseAlbum = await this.getBaseAlbumId(groupId);
-
-    if (albumId === baseAlbum.albumId) throw new NotFoundException("It cannot be deleted because it is baseAlbum.");
-
     await this.movePosts(albumId, baseAlbum);
+
     this.albumRepository.softRemove(album);
 
     return "Album delete success!!";

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,8 +6,17 @@ import { AuthModule } from "./auth/auth.module";
 import { GroupModule } from "./group/group.module";
 import { AlbumModule } from "./album/album.module";
 import { PostModule } from "./post/post.module";
+import { HashtagModule } from "./hashtag/hashtag.module";
 
 @Module({
-  imports: [TypeOrmModule.forRoot(typeORMConfig), UserModule, AuthModule, GroupModule, AlbumModule, PostModule],
+  imports: [
+    TypeOrmModule.forRoot(typeORMConfig),
+    UserModule,
+    AuthModule,
+    GroupModule,
+    AlbumModule,
+    PostModule,
+    HashtagModule,
+  ],
 })
 export class AppModule {}

--- a/backend/src/dto/album/deleteAlbumRequest.dto.ts
+++ b/backend/src/dto/album/deleteAlbumRequest.dto.ts
@@ -1,9 +1,0 @@
-import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsNumber } from "class-validator";
-
-export class DeleteAlbumRequestDto {
-  @IsNumber()
-  @IsNotEmpty()
-  @ApiProperty()
-  groupId: number;
-}

--- a/backend/src/dto/group/createGroupResponse.dto.ts
+++ b/backend/src/dto/group/createGroupResponse.dto.ts
@@ -1,0 +1,14 @@
+import { IsNotEmpty, IsNumber, IsString } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class CreateGroupResponseDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty()
+  groupImage: string;
+
+  @IsNumber()
+  @IsNotEmpty()
+  @ApiProperty()
+  groupId: number;
+}

--- a/backend/src/dto/group/updateGroupInfoResponse.dto.ts
+++ b/backend/src/dto/group/updateGroupInfoResponse.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class UpdateGroupInfoResponseDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty()
+  groupImage: string;
+}

--- a/backend/src/group/controller/group.controller.ts
+++ b/backend/src/group/controller/group.controller.ts
@@ -23,6 +23,8 @@ import { GetGroupInfoResponseDto } from "src/dto/group/getGroupInfoResponse.dto"
 import { UpdateGroupInfoRequestDto } from "src/dto/group/updateGroupInfoRequest.dto";
 import { GetAlbumsResponseDto } from "src/dto/group/getAlbumsResponse.dto";
 import { UpdateAlbumOrderRequestDto } from "src/dto/group/updateAlbumOrderRequest.dto";
+import { CreateGroupResponseDto } from "src/dto/group/createGroupResponse.dto";
+import { UpdateGroupInfoResponseDto } from "src/dto/group/updateGroupInfoResponse.dto";
 import { FileInterceptor } from "@nestjs/platform-express";
 import { multerOption } from "src/image/service/image.service";
 
@@ -38,12 +40,12 @@ export class GroupController {
   @UseInterceptors(FileInterceptor("groupImage", multerOption))
   @ApiConsumes("multipart/form-data")
   @ApiBody({ type: CreateGroupRequestDto })
-  @ApiResponse({ type: Number, description: "생성된 그룹 ID", status: 200 })
+  @ApiResponse({ type: CreateGroupResponseDto, status: 200 })
   CreateGroup(
     @Req() { user }: CustomRequest,
     @Body() createGroupRequestDto: CreateGroupRequestDto,
     @UploadedFile() file: CustomFile,
-  ): Promise<number> {
+  ): Promise<CreateGroupResponseDto> {
     const { userId } = user;
     return this.groupService.createGroup(userId, file, createGroupRequestDto);
   }
@@ -76,12 +78,12 @@ export class GroupController {
   @ApiConsumes("multipart/form-data")
   @ApiBody({ type: UpdateGroupInfoRequestDto })
   @ApiParam({ name: "groupId", type: Number })
-  @ApiOkResponse({ description: "그룹 수정 성공" })
+  @ApiResponse({ type: UpdateGroupInfoResponseDto, status: 200 })
   UpdateGroupInfo(
     @Param("groupId") groupId: number,
     @Body() updateGroupInfoRequestDto: UpdateGroupInfoRequestDto,
     @UploadedFile() file: CustomFile,
-  ): Promise<string> {
+  ): Promise<UpdateGroupInfoResponseDto> {
     return this.groupService.updateGroupInfo(groupId, file, updateGroupInfoRequestDto);
   }
 

--- a/backend/src/group/group.entity.ts
+++ b/backend/src/group/group.entity.ts
@@ -2,6 +2,7 @@ import { Entity, PrimaryGeneratedColumn, Column, ManyToMany, JoinTable, OneToMan
 import { TimeStampEntity } from "src/custom/myBaseEntity/timestampEntity";
 import { User } from "src/user/user.entity";
 import { Album } from "src/album/album.entity";
+import { HashTag } from "src/hashtag/hashtag.entity";
 
 @Entity({ name: "groups_TB" })
 export class Group extends TimeStampEntity {
@@ -26,4 +27,7 @@ export class Group extends TimeStampEntity {
 
   @OneToMany(() => Album, album => album.group, { cascade: true })
   albums: Album[];
+
+  @OneToMany(() => HashTag, hashtag => hashtag.group, { cascade: true })
+  hashtags: HashTag[];
 }

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -11,6 +11,8 @@ import { GetGroupInfoResponseDto } from "src/dto/group/getGroupInfoResponse.dto"
 import { UpdateGroupInfoRequestDto } from "src/dto/group/updateGroupInfoRequest.dto";
 import { GetAlbumsResponseDto } from "src/dto/group/getAlbumsResponse.dto";
 import { UpdateAlbumOrderRequestDto } from "src/dto/group/updateAlbumOrderRequest.dto";
+import { CreateGroupResponseDto } from "src/dto/group/createGroupResponse.dto";
+import { UpdateGroupInfoResponseDto } from "src/dto/group/updateGroupInfoResponse.dto";
 import { AlbumService } from "src/album/service/album.service";
 import { ImageService } from "src/image/service/image.service";
 
@@ -27,7 +29,11 @@ export class GroupService {
     private albumRepository: AlbumRepository,
   ) {}
 
-  async createGroup(userId: number, file: CustomFile, createGroupRequestDto: CreateGroupRequestDto): Promise<number> {
+  async createGroup(
+    userId: number,
+    file: CustomFile,
+    createGroupRequestDto: CreateGroupRequestDto,
+  ): Promise<CreateGroupResponseDto> {
     const groupImage = this.imageService.getImageUrl(file);
     const { groupName } = createGroupRequestDto;
     const groupCode = await this.createInvitaionCode();
@@ -48,7 +54,7 @@ export class GroupService {
 
     await this.applyUserEntity(userId, groupId, group);
 
-    return groupId;
+    return { groupId, groupImage };
   }
 
   async createInvitaionCode(): Promise<string> {
@@ -96,7 +102,7 @@ export class GroupService {
     groupId: number,
     file: CustomFile,
     updateGroupInfoRequestDto: UpdateGroupInfoRequestDto,
-  ): Promise<string> {
+  ): Promise<UpdateGroupInfoResponseDto> {
     const groupImage = this.imageService.getImageUrl(file);
     const { groupName } = updateGroupInfoRequestDto;
 
@@ -107,7 +113,7 @@ export class GroupService {
 
     this.groupRepository.update(groupId, updateObject);
 
-    return "GroupInfo update success!!";
+    return { groupImage };
   }
 
   async leaveGroup(userId: number, groupId: number): Promise<string> {

--- a/backend/src/hashtag/hashtag.entity.ts
+++ b/backend/src/hashtag/hashtag.entity.ts
@@ -1,0 +1,27 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToMany, JoinTable, ManyToOne, JoinColumn } from "typeorm";
+import { TimeStampEntity } from "src/custom/myBaseEntity/timestampEntity";
+import { Post } from "src/post/post.entity";
+import { Group } from "src/group/group.entity";
+
+@Entity({ name: "hashtags" })
+export class HashTag extends TimeStampEntity {
+  @PrimaryGeneratedColumn()
+  hashtagId: number;
+
+  @Column()
+  hashtagContent: string;
+
+  @ManyToMany(() => Post)
+  @JoinTable({ name: "posts_hashtags" })
+  posts: Post[];
+
+  @ManyToOne(() => Group, group => group.hashtags, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "group_id" })
+  group: Group;
+
+  constructor(hashtagContent: string, group: Group) {
+    super();
+    this.hashtagContent = hashtagContent;
+    this.group = group;
+  }
+}

--- a/backend/src/hashtag/hashtag.module.ts
+++ b/backend/src/hashtag/hashtag.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { JwtModule } from "@nestjs/jwt";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { GroupRepository } from "src/group/group.repository";
+import { HashTagRepository } from "./hashtag.repository";
+import { HashTagService } from "./service/hashtag.service";
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([HashTagRepository, GroupRepository]),
+    JwtModule.register({
+      secret: process.env.JWT_SECRET,
+    }),
+  ],
+  providers: [HashTagService],
+  exports: [HashTagService],
+})
+export class HashtagModule {}

--- a/backend/src/hashtag/hashtag.repository.ts
+++ b/backend/src/hashtag/hashtag.repository.ts
@@ -1,0 +1,5 @@
+import { EntityRepository, Repository } from "typeorm";
+import { HashTag } from "./hashtag.entity";
+
+@EntityRepository(HashTag)
+export class HashTagRepository extends Repository<HashTag> {}

--- a/backend/src/hashtag/service/hashtag.service.spec.ts
+++ b/backend/src/hashtag/service/hashtag.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { HashTagService } from "./hashtag.service";
+
+describe("HashtagService", () => {
+  let service: HashTagService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [HashTagService],
+    }).compile();
+
+    service = module.get<HashTagService>(HashTagService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/hashtag/service/hashtag.service.ts
+++ b/backend/src/hashtag/service/hashtag.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { HashTagRepository } from "../hashtag.repository";
+import { HashTag } from "../hashtag.entity";
+import { GroupRepository } from "src/group/group.repository";
+
+@Injectable()
+export class HashTagService {
+  constructor(
+    @InjectRepository(HashTagRepository)
+    private hashTagRepository: HashTagRepository,
+    @InjectRepository(GroupRepository)
+    private groupRepository: GroupRepository,
+  ) {}
+
+  async saveHashTag(groupId: number, hashTags: RegExpMatchArray): Promise<HashTag[]> {
+    const group = await this.groupRepository.findOne(groupId);
+
+    return await Promise.all(
+      hashTags?.map(async e => {
+        const hashtagContent = e;
+
+        const exits = await this.hashTagRepository.findOne({ hashtagContent });
+
+        if (!exits) {
+          const hashtag = new HashTag(hashtagContent, group);
+          return hashtag;
+        }
+
+        return exits;
+      }),
+    );
+  }
+}

--- a/backend/src/post/post.entity.ts
+++ b/backend/src/post/post.entity.ts
@@ -1,8 +1,18 @@
 import { Album } from "src/album/album.entity";
 import { TimeStampEntity } from "src/custom/myBaseEntity/timestampEntity";
-import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn, OneToMany } from "typeorm";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  JoinColumn,
+  OneToMany,
+  ManyToMany,
+  JoinTable,
+} from "typeorm";
 import { Image } from "src/image/image.entity";
 import { User } from "src/user/user.entity";
+import { HashTag } from "src/hashtag/hashtag.entity";
 
 @Entity({ name: "posts" })
 export class Post extends TimeStampEntity {
@@ -27,6 +37,9 @@ export class Post extends TimeStampEntity {
   @Column({ type: "decimal", precision: 18, scale: 10 })
   postLongitude: number;
 
+  @Column({ nullable: true })
+  hashtagCategory: string;
+
   @ManyToOne(() => Album, album => album.posts)
   @JoinColumn({ name: "album_id" })
   album: Album;
@@ -37,4 +50,8 @@ export class Post extends TimeStampEntity {
 
   @OneToMany(() => Image, image => image.post, { cascade: true })
   images: Image[];
+
+  @ManyToMany(() => HashTag, { cascade: true })
+  @JoinTable({ name: "posts_hashtags" })
+  hashtags: HashTag[];
 }

--- a/backend/src/post/post.module.ts
+++ b/backend/src/post/post.module.ts
@@ -8,11 +8,13 @@ import { UserRepository } from "src/user/user.repository";
 import { AlbumRepository } from "src/album/album.repository";
 import { ImageModule } from "src/image/image.module";
 import { AlbumModule } from "src/album/album.module";
+import { HashtagModule } from "src/hashtag/hashtag.module";
 
 @Module({
   imports: [
     ImageModule,
     AlbumModule,
+    HashtagModule,
     TypeOrmModule.forFeature([PostRepository, UserRepository, AlbumRepository]),
     JwtModule.register({
       secret: process.env.JWT_SECRET,


### PR DESCRIPTION
## 작업 내용
- 게시글 생성시 해시태그도 같이 생성
- 그룹 생성, 수정 API 응답 수정
- 앨범 삭제 body 제거

## 고민한 부분
게시글 과 해시태그는 manyTomany가 맞다
게시글에서 해시태그 여러 개 가능, 해시태그에서 게시글 여러 개 가능

근데 게시글에서는 해시태그를 조회할 일이 없다
오로지 해시태그와 연관된 게시글이 뭐가 있는지를 위해 사용하는 것

그래서 그냥 생성시에는 user-group 처럼 짜면 될듯 싶은데
수정시에는?? 기존 해시태그가 뭔지 알아야하고 바뀐 해시태그가 뭔지 알아야한다.

기존 해시태그와 새로온 해시태그에서 교집합인 해시태그는 그냥 놔두고
기존 해시태그에 없는 새로운 해시태그는 추가해준다.
새로운 해시태그에 없는 기존 해시태그는 삭제해주면 된다.

위 내용으로 오늘은 생성만 구현했는데

먼저 해시태그 string을 ,로 묶고 게시글에 있는 해시태그 컬럼에 추가
- A 함수라고 가정
  - 해시태그를 돌면서 해시태그가 존재하면 저장하지말고 그 해시태그에 게시글을 푸쉬
  - 해시태그가 존재하지 않으면 저장하고 그 해시태그에 게시글을 푸쉬
수정시에도 A함수를 사용한다.
수정은 내일 구현할 예정

## 리뷰 포인트
감사합니당

## 관련된 이슈 넘버
#146 