### PR TITLE
API 수정 및 그룹의 전체 해시태그 검색 API 구현

### DIFF
--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -32,7 +32,7 @@ export class AlbumService {
     const { albumId } = album;
 
     const { albumOrder } = group;
-    const newAlbumOrder = `${albumOrder},${albumId}`;
+    const newAlbumOrder = `${albumId},${albumOrder}`;
     await this.groupRepository.update(groupId, { albumOrder: newAlbumOrder });
 
     return { albumId };

--- a/backend/src/album/service/album.service.ts
+++ b/backend/src/album/service/album.service.ts
@@ -61,7 +61,18 @@ export class AlbumService {
 
     this.albumRepository.softRemove(album);
 
+    const { albumOrder } = group;
+    const reArrangedOrder = this.reArrangeAlbums(albumOrder, albumId);
+
+    await this.groupRepository.update(groupId, { albumOrder: reArrangedOrder });
+
     return "Album delete success!!";
+  }
+
+  reArrangeAlbums(albumOrder: string, albumId: number): string {
+    const order = albumOrder.split(",");
+
+    return order.filter(e => +e !== albumId).join(",");
   }
 
   async getBaseAlbumId(groupId: number): Promise<Album> {

--- a/backend/src/dto/group/getHashTagsResponse.dto.ts
+++ b/backend/src/dto/group/getHashTagsResponse.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsNumber, IsString, IsArray } from "class-validator";
+
+class hashTagList {
+  @IsNumber()
+  @IsNotEmpty()
+  @ApiProperty()
+  hashtagId: number;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty()
+  hashtagContent: string;
+}
+
+export class GetHashTagsResponseDto {
+  @IsArray()
+  @IsNotEmpty()
+  @ApiProperty({ type: [hashTagList] })
+  hashtags: hashTagList[];
+}

--- a/backend/src/dto/post/updatePostInfoRequest.dto.ts
+++ b/backend/src/dto/post/updatePostInfoRequest.dto.ts
@@ -1,7 +1,7 @@
 import { PostInfo } from "./postInfo";
 import { ApiProperty } from "@nestjs/swagger";
-import { Type } from "class-transformer";
-import { IsOptional } from "class-validator";
+import { Type, Transform } from "class-transformer";
+import { IsNotEmpty, IsNumber, IsOptional } from "class-validator";
 
 export class UpdatePostInfoRequestDto extends PostInfo {
   @IsOptional()
@@ -12,4 +12,10 @@ export class UpdatePostInfoRequestDto extends PostInfo {
   @IsOptional()
   @ApiProperty({ type: ["file"] })
   addImages: any[];
+
+  @IsNumber()
+  @IsNotEmpty()
+  @Transform(({ value }) => Number(value))
+  @ApiProperty()
+  groupId: number;
 }

--- a/backend/src/group/controller/group.controller.ts
+++ b/backend/src/group/controller/group.controller.ts
@@ -25,6 +25,7 @@ import { GetAlbumsResponseDto } from "src/dto/group/getAlbumsResponse.dto";
 import { UpdateAlbumOrderRequestDto } from "src/dto/group/updateAlbumOrderRequest.dto";
 import { CreateGroupResponseDto } from "src/dto/group/createGroupResponse.dto";
 import { UpdateGroupInfoResponseDto } from "src/dto/group/updateGroupInfoResponse.dto";
+import { GetHashTagsResponseDto } from "src/dto/group/getHashTagsResponse.dto";
 import { FileInterceptor } from "@nestjs/platform-express";
 import { multerOption } from "src/image/service/image.service";
 
@@ -104,5 +105,12 @@ export class GroupController {
     @Body() updateAlbumOrderRequestDto: UpdateAlbumOrderRequestDto,
   ): Promise<string> {
     return this.groupService.updateAlbumOrder(groupId, updateAlbumOrderRequestDto);
+  }
+
+  @Get("/:groupId/hashtags")
+  @ApiParam({ name: "groupId", type: Number })
+  @ApiResponse({ type: GetHashTagsResponseDto, status: 200 })
+  GetHashTags(@Param("groupId") groupId: number): Promise<GetHashTagsResponseDto> {
+    return this.groupService.getHashTags(groupId);
   }
 }

--- a/backend/src/group/group.repository.ts
+++ b/backend/src/group/group.repository.ts
@@ -46,4 +46,12 @@ export class GroupRepository extends Repository<Group> {
       .where("group.groupId = :id AND album.base = :base", { id: groupId, base: base })
       .getOne();
   }
+
+  async getHashTagsQuery(groupId: number): Promise<Group> {
+    return await this.createQueryBuilder("group")
+      .leftJoin("group.hashtags", "hashtag")
+      .select(["group.groupId", "hashtag.hashtagId", "hashtag.hashtagContent"])
+      .where("group.groupId=:id", { id: groupId })
+      .getOne();
+  }
 }

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -13,6 +13,7 @@ import { GetAlbumsResponseDto } from "src/dto/group/getAlbumsResponse.dto";
 import { UpdateAlbumOrderRequestDto } from "src/dto/group/updateAlbumOrderRequest.dto";
 import { CreateGroupResponseDto } from "src/dto/group/createGroupResponse.dto";
 import { UpdateGroupInfoResponseDto } from "src/dto/group/updateGroupInfoResponse.dto";
+import { GetHashTagsResponseDto } from "src/dto/group/getHashTagsResponse.dto";
 import { AlbumService } from "src/album/service/album.service";
 import { ImageService } from "src/image/service/image.service";
 
@@ -178,5 +179,12 @@ export class GroupService {
     }, {});
 
     return result;
+  }
+
+  async getHashTags(groupId: number): Promise<GetHashTagsResponseDto> {
+    const group = await this.groupRepository.getHashTagsQuery(groupId);
+    console.log(group);
+
+    return new GetHashTagsResponseDto();
   }
 }

--- a/backend/src/hashtag/hashtag.entity.ts
+++ b/backend/src/hashtag/hashtag.entity.ts
@@ -11,7 +11,7 @@ export class HashTag extends TimeStampEntity {
   @Column()
   hashtagContent: string;
 
-  @ManyToMany(() => Post)
+  @ManyToMany(() => Post, { onUpdate: "CASCADE" })
   @JoinTable({ name: "posts_hashtags" })
   posts: Post[];
 

--- a/backend/src/hashtag/hashtag.entity.ts
+++ b/backend/src/hashtag/hashtag.entity.ts
@@ -18,10 +18,4 @@ export class HashTag extends TimeStampEntity {
   @ManyToOne(() => Group, group => group.hashtags, { onDelete: "CASCADE" })
   @JoinColumn({ name: "group_id" })
   group: Group;
-
-  constructor(hashtagContent: string, group: Group) {
-    super();
-    this.hashtagContent = hashtagContent;
-    this.group = group;
-  }
 }

--- a/backend/src/hashtag/service/hashtag.service.ts
+++ b/backend/src/hashtag/service/hashtag.service.ts
@@ -23,7 +23,9 @@ export class HashTagService {
         const exits = await this.hashTagRepository.findOne({ hashtagContent });
 
         if (!exits) {
-          const hashtag = new HashTag(hashtagContent, group);
+          const hashtag = new HashTag();
+          hashtag.hashtagContent = hashtagContent;
+          hashtag.group = group;
           return hashtag;
         }
 

--- a/backend/src/hashtag/service/hashtag.service.ts
+++ b/backend/src/hashtag/service/hashtag.service.ts
@@ -13,7 +13,7 @@ export class HashTagService {
     private groupRepository: GroupRepository,
   ) {}
 
-  async saveHashTag(groupId: number, hashTags: RegExpMatchArray): Promise<HashTag[]> {
+  async makeHashTag(groupId: number, hashTags: string[]): Promise<HashTag[]> {
     const group = await this.groupRepository.findOne(groupId);
 
     return await Promise.all(

--- a/backend/src/image/service/image.service.ts
+++ b/backend/src/image/service/image.service.ts
@@ -57,9 +57,11 @@ export class ImageService {
 
   async updateImages(post: Post, addImages: string[], deleteImagesId: number[]): Promise<void> {
     if (deleteImagesId)
-      deleteImagesId.forEach(imageId => {
-        this.imageRepository.softRemove({ imageId });
-      });
+      typeof deleteImagesId === "number"
+        ? this.imageRepository.softRemove({ imageId: deleteImagesId })
+        : deleteImagesId.forEach(imageId => {
+            this.imageRepository.softRemove({ imageId });
+          });
     for (const image of addImages) {
       await this.imageRepository.save({
         imageUrl: image,

--- a/backend/src/post/post.repository.ts
+++ b/backend/src/post/post.repository.ts
@@ -1,4 +1,4 @@
-import { EntityRepository, Repository } from "typeorm";
+import { EntityRepository, Repository, DeleteResult } from "typeorm";
 import { Post } from "./post.entity";
 
 @EntityRepository(Post)
@@ -20,5 +20,13 @@ export class PostRepository extends Repository<Post> {
       ])
       .where("post.postId = :id", { id: postId })
       .getOne();
+  }
+
+  async deleteHashTagsQuery(postId: number): Promise<DeleteResult> {
+    return await this.createQueryBuilder()
+      .delete()
+      .from("posts_hashtags")
+      .where("posts_post_id=:postId", { postId: postId })
+      .execute();
   }
 }


### PR DESCRIPTION
## 작업 내용
- 앨범 삭제 시 order 갱신
- 앨범 생성시 가장 최상단에 위치하게 수정
- 그룹 전체 해시태그 검색 API 구현
- 게시글 수정시 해시태그 변경 추가

## 고민한 부분
- 기존 하려고 했던 로직
  - 기존에 저장되어 있는 해시태그들과 새로 들어온 해시태그들을 비교
  - 교집합 패스
  - 기존 해시태그에 없는 새로운 해시태그들은 생성
  - 새로운 해시태그에 없는 기존 해시태그들은 게시글-해시태그 연관 테이블에서 삭제
- 변경한 로직
  - 비교해서 개별 삭제보단 다 날리는게 나을 것 같다는 판단
  - 왜냐면 삭제할 해시태그들을 for문돌면서 하나씩 지워야된다.
  - 그렇다고 해시태그 ID를 저장해놓으면 변경된 해시태그들을 비교하기 위해서는 해시태그 테이블을 돌면서 id를 전부 가져와야한다.
  - 결국 오버헤드는 똑같은데 쿼리 요청을 더 적게하는 쪽으로 하는게 나을듯 싶었다.

## 리뷰 포인트
감사합니당

## 관련된 이슈 넘버
#179 