### PR TITLE
jwt 에러처리 로직 추가 및 해시태그 클릭시 리스트 조회 API 구현

### DIFF
--- a/backend/src/album/controller/album.controller.ts
+++ b/backend/src/album/controller/album.controller.ts
@@ -9,7 +9,7 @@ import { CreateAlbumResponseDto } from "src/dto/album/createAlbumResponse.dto";
 @ApiTags("앨범 API")
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
-@Controller("api/albums")
+@Controller("albums")
 export class AlbumController {
   constructor(private readonly albumService: AlbumService) {}
 

--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -23,11 +23,11 @@ export class AuthController {
   async naverAuthRedirect(@Req() { user }: CustomRequest, @Res() res: Response) {
     const { accessToken, refreshToken } = user;
 
-    const oneHour = 1000 * 60 * 60;
-    const oneWeek = oneHour * 24 * 7;
+    const accessTokenTokenExpireTime = 1000 * 60 * 60;
+    const refreshTokenExpireTime = accessTokenTokenExpireTime * 24 * 7;
 
-    res.cookie("accessToken", accessToken, { maxAge: oneHour });
-    res.cookie("refreshToken", refreshToken, { maxAge: oneWeek });
+    res.cookie("accessToken", accessToken, { maxAge: accessTokenTokenExpireTime });
+    res.cookie("refreshToken", refreshToken, { maxAge: refreshTokenExpireTime });
 
     const redirectUrl = process.env.NODE_ENV === "dev" ? process.env.DEV_REDIRECT_URL : process.env.PROD_REDIRECT_URL;
 

--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -8,7 +8,7 @@ import { UserService } from "src/user/service/user.service";
 
 @ApiTags("auth API")
 @ApiBearerAuth()
-@Controller("/api/auth")
+@Controller("/auth")
 export class AuthController {
   constructor(private readonly userService: UserService) {}
 

--- a/backend/src/auth/guard/jwt-auth-guard.ts
+++ b/backend/src/auth/guard/jwt-auth-guard.ts
@@ -24,8 +24,8 @@ export class JwtAuthGuard extends AuthGuard("jwt") {
     if (!validationRefreshToken) throw new UnauthorizedException("토큰이 존재하지 않습니다.");
 
     const { userId } = validationRefreshToken;
-    const oneHour = "1h";
-    const newAccessToken = this.createToken(userId, oneHour);
+    const accessTokenExpireTime = "1h";
+    const newAccessToken = this.createToken(userId, accessTokenExpireTime);
     response.cookie("accessToken", newAccessToken);
     request.user = validationRefreshToken;
 

--- a/backend/src/auth/guard/jwt-auth-guard.ts
+++ b/backend/src/auth/guard/jwt-auth-guard.ts
@@ -15,7 +15,6 @@ export class JwtAuthGuard extends AuthGuard("jwt") {
     const { accessToken, refreshToken } = request.cookies;
 
     const validationAccessToken = await this.validateToken(accessToken);
-
     if (validationAccessToken) {
       request.user = validationAccessToken;
       return true;
@@ -24,19 +23,22 @@ export class JwtAuthGuard extends AuthGuard("jwt") {
     const validationRefreshToken = await this.validateToken(refreshToken);
     if (!validationRefreshToken) throw new UnauthorizedException("토큰이 존재하지 않습니다.");
 
-    request.user = validationRefreshToken;
-
     const { userId } = validationRefreshToken;
-    const updateAccessToken = this.createToken(userId, "1h");
-    response.cookie("accessToken", updateAccessToken);
+    const oneHour = "1h";
+    const newAccessToken = this.createToken(userId, oneHour);
+    response.cookie("accessToken", newAccessToken);
+    request.user = validationRefreshToken;
 
     return true;
   }
 
   async validateToken(token: string): Promise<{ userId: number }> {
-    const { userId } = await this.jwtService.verify(token);
-
-    return { userId: userId };
+    try {
+      const { userId } = await this.jwtService.verify(token);
+      return { userId: userId };
+    } catch (e) {
+      return undefined;
+    }
   }
 
   createToken(userId: number, expire: string): string {

--- a/backend/src/auth/strategy/naver.strategy.ts
+++ b/backend/src/auth/strategy/naver.strategy.ts
@@ -31,8 +31,10 @@ export class NaverStrategy extends PassportStrategy(Strategy, "naver") {
 
     const { userId } = user;
 
-    const accessToken = this.authService.createToken(userId, "1h");
-    const refreshToken = this.authService.createToken(userId, "7d");
+    const oneHour = "1h";
+    const oneWeek = "7d";
+    const accessToken = this.authService.createToken(userId, oneHour);
+    const refreshToken = this.authService.createToken(userId, oneWeek);
 
     await this.userService.updateToken(userId, refreshToken);
 

--- a/backend/src/auth/strategy/naver.strategy.ts
+++ b/backend/src/auth/strategy/naver.strategy.ts
@@ -31,10 +31,10 @@ export class NaverStrategy extends PassportStrategy(Strategy, "naver") {
 
     const { userId } = user;
 
-    const oneHour = "1h";
-    const oneWeek = "7d";
-    const accessToken = this.authService.createToken(userId, oneHour);
-    const refreshToken = this.authService.createToken(userId, oneWeek);
+    const accessTokenExpireTime = "1h";
+    const refreshTokenExpireTime = "7d";
+    const accessToken = this.authService.createToken(userId, accessTokenExpireTime);
+    const refreshToken = this.authService.createToken(userId, refreshTokenExpireTime);
 
     await this.userService.updateToken(userId, refreshToken);
 

--- a/backend/src/dto/post/getSearchPostResponse.dto.ts
+++ b/backend/src/dto/post/getSearchPostResponse.dto.ts
@@ -1,0 +1,26 @@
+import { IsArray, IsNotEmpty, IsNumber, IsString } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+
+class postList {
+  @IsNumber()
+  @IsNotEmpty()
+  @ApiProperty()
+  postId: number;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty()
+  postTitle: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty()
+  postDate: Date;
+}
+
+export class GetSearchPostResponse {
+  @IsArray()
+  @IsNotEmpty()
+  @ApiProperty({ type: [postList] })
+  posts: postList[];
+}

--- a/backend/src/group/controller/group.controller.ts
+++ b/backend/src/group/controller/group.controller.ts
@@ -32,7 +32,7 @@ import { multerOption } from "src/image/service/image.service";
 @ApiTags("그룹 API")
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
-@Controller("api/groups")
+@Controller("groups")
 export class GroupController {
   constructor(private readonly groupService: GroupService) {}
 

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -182,9 +182,8 @@ export class GroupService {
   }
 
   async getHashTags(groupId: number): Promise<GetHashTagsResponseDto> {
-    const group = await this.groupRepository.getHashTagsQuery(groupId);
-    console.log(group);
+    const { hashtags } = await this.groupRepository.getHashTagsQuery(groupId);
 
-    return new GetHashTagsResponseDto();
+    return { hashtags };
   }
 }

--- a/backend/src/hashtag/hashtag.repository.ts
+++ b/backend/src/hashtag/hashtag.repository.ts
@@ -2,4 +2,12 @@ import { EntityRepository, Repository } from "typeorm";
 import { HashTag } from "./hashtag.entity";
 
 @EntityRepository(HashTag)
-export class HashTagRepository extends Repository<HashTag> {}
+export class HashTagRepository extends Repository<HashTag> {
+  async getSearchPosts(hashtagId: number): Promise<HashTag> {
+    return await this.createQueryBuilder("hashtag")
+      .leftJoin("hashtag.posts", "post")
+      .select(["hashtag.hashtagId", "post.postId", "post.postTitle", "post.postDate"])
+      .where("hashtag.hashtagId=:id", { id: hashtagId })
+      .getOne();
+  }
+}

--- a/backend/src/hashtag/service/hashtag.service.ts
+++ b/backend/src/hashtag/service/hashtag.service.ts
@@ -20,7 +20,7 @@ export class HashTagService {
       hashTags?.map(async e => {
         const hashtagContent = e;
 
-        const exits = await this.hashTagRepository.findOne({ hashtagContent });
+        const exits = await this.hashTagRepository.findOne({ hashtagContent, group });
 
         if (!exits) {
           const hashtag = new HashTag();

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -5,18 +5,14 @@ import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { AppModule } from "./app.module";
 
 const options = {
-  origin: ["http://localhost:3000"],
-  methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
-  preflightContinue: false,
-  optionsSuccessStatus: 204,
+  origin: process.env.FRONT_LOCALHOST,
   credentials: true,
 };
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  app.enableCors(options);
-
+  process.env.NODE_ENV === "dev" && app.enableCors(options);
   app.use(cookieParser());
   app.setGlobalPrefix("/api");
   app.useGlobalPipes(

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -18,7 +18,7 @@ async function bootstrap() {
   app.enableCors(options);
 
   app.use(cookieParser());
-
+  app.setGlobalPrefix("/api");
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,

--- a/backend/src/post/controller/post.controller.ts
+++ b/backend/src/post/controller/post.controller.ts
@@ -37,7 +37,7 @@ import { multerOption } from "src/image/service/image.service";
 @ApiTags("게시글 API")
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
-@Controller("api/posts")
+@Controller("posts")
 export class PostController {
   constructor(private readonly postService: PostService) {}
 

--- a/backend/src/post/controller/post.controller.ts
+++ b/backend/src/post/controller/post.controller.ts
@@ -11,8 +11,18 @@ import {
   UseGuards,
   UseInterceptors,
   UploadedFiles,
+  Query,
 } from "@nestjs/common";
-import { ApiTags, ApiOkResponse, ApiParam, ApiResponse, ApiBearerAuth, ApiConsumes, ApiBody } from "@nestjs/swagger";
+import {
+  ApiTags,
+  ApiOkResponse,
+  ApiParam,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiConsumes,
+  ApiBody,
+  ApiQuery,
+} from "@nestjs/swagger";
 import { CustomRequest } from "src/custom//myRequest/customRequest";
 import { JwtAuthGuard } from "src/auth/guard/jwt-auth-guard";
 import { PostService } from "../service/post.service";
@@ -20,6 +30,7 @@ import { CreatePostRequestDto } from "src/dto/post/createPostRequest.dto";
 import { GetPostInfoResponseDto } from "src/dto/post/getPostInfoResponse.dto";
 import { UpdatePostInfoRequestDto } from "src/dto/post/updatePostInfoRequest.dto";
 import { ShiftPostRequestDto } from "src/dto/post/shiftPostRequest.dto";
+import { GetSearchPostResponse } from "src/dto/post/getSearchPostResponse.dto";
 import { FilesInterceptor } from "@nestjs/platform-express";
 import { multerOption } from "src/image/service/image.service";
 
@@ -44,6 +55,13 @@ export class PostController {
     const { userId } = user;
 
     return this.postService.createPost(userId, files, createPostRequestDto);
+  }
+
+  @Get("/search")
+  @ApiQuery({ name: "hashtagId", required: true })
+  @ApiResponse({ type: GetSearchPostResponse, status: 200 })
+  GetSearchPost(@Query("hashtagId") hashtagId: number): Promise<GetSearchPostResponse> {
+    return this.postService.getSearchPost(hashtagId);
   }
 
   @Get("/:postId")

--- a/backend/src/post/controller/post.controller.ts
+++ b/backend/src/post/controller/post.controller.ts
@@ -54,9 +54,9 @@ export class PostController {
   }
 
   @Put("/:postId")
+  @UseInterceptors(FilesInterceptor("addImages", 5, multerOption))
   @ApiConsumes("multipart/form-data")
   @ApiBody({ type: UpdatePostInfoRequestDto })
-  @UseInterceptors(FilesInterceptor("addImages", 5, multerOption))
   @ApiParam({ name: "postId", type: Number })
   @ApiOkResponse({ description: "게시글 수정 성공" })
   UpdatePost(
@@ -73,8 +73,9 @@ export class PostController {
   @Delete("/:postId")
   @ApiParam({ name: "postId", type: Number })
   @ApiOkResponse({ description: "게시글 삭제 성공" })
-  DeletePost(@Param("postId") postId: number): Promise<string> {
-    return this.postService.deletePost(postId);
+  DeletePost(@Req() { user }: CustomRequest, @Param("postId") postId: number): Promise<string> {
+    const { userId } = user;
+    return this.postService.deletePost(userId, postId);
   }
 
   @Put("/:postId/shift")

--- a/backend/src/post/post.entity.ts
+++ b/backend/src/post/post.entity.ts
@@ -37,9 +37,6 @@ export class Post extends TimeStampEntity {
   @Column({ type: "decimal", precision: 18, scale: 10 })
   postLongitude: number;
 
-  @Column({ nullable: true })
-  hashtagCategory: string;
-
   @ManyToOne(() => Album, album => album.posts)
   @JoinColumn({ name: "album_id" })
   album: Album;

--- a/backend/src/post/post.module.ts
+++ b/backend/src/post/post.module.ts
@@ -9,13 +9,14 @@ import { AlbumRepository } from "src/album/album.repository";
 import { ImageModule } from "src/image/image.module";
 import { AlbumModule } from "src/album/album.module";
 import { HashtagModule } from "src/hashtag/hashtag.module";
+import { HashTagRepository } from "src/hashtag/hashtag.repository";
 
 @Module({
   imports: [
     ImageModule,
     AlbumModule,
     HashtagModule,
-    TypeOrmModule.forFeature([PostRepository, UserRepository, AlbumRepository]),
+    TypeOrmModule.forFeature([PostRepository, UserRepository, AlbumRepository, HashTagRepository]),
     JwtModule.register({
       secret: process.env.JWT_SECRET,
     }),

--- a/backend/src/post/service/post.service.ts
+++ b/backend/src/post/service/post.service.ts
@@ -107,7 +107,7 @@ export class PostService {
       updatePostInfoRequestDto;
 
     const relations = ["user"];
-    const post = await this.validatedUserAuthor(userId, postId, relations);
+    const post = await this.validateUserAuthor(userId, postId, relations);
 
     await this.postRepository.deleteHashTagsQuery(postId);
 
@@ -132,14 +132,14 @@ export class PostService {
 
   async deletePost(userId: number, postId: number): Promise<string> {
     const relations = ["user", "images"];
-    const post = await this.validatedUserAuthor(userId, postId, relations);
+    const post = await this.validateUserAuthor(userId, postId, relations);
 
     this.postRepository.softRemove(post);
 
     return "Post delete success!!";
   }
 
-  async validatedUserAuthor(userId: number, postId: number, relations: Array<string>): Promise<Post> {
+  async validateUserAuthor(userId: number, postId: number, relations: Array<string>): Promise<Post> {
     const post = await this.postRepository.findOne(postId, { relations: relations });
     if (!post) throw new NotFoundException(`Not found post with the id ${postId}`);
 

--- a/backend/src/post/service/post.service.ts
+++ b/backend/src/post/service/post.service.ts
@@ -8,10 +8,12 @@ import { CreatePostRequestDto } from "src/dto/post/createPostRequest.dto";
 import { GetPostInfoResponseDto } from "src/dto/post/getPostInfoResponse.dto";
 import { UpdatePostInfoRequestDto } from "src/dto/post/updatePostInfoRequest.dto";
 import { ShiftPostRequestDto } from "src/dto/post/shiftPostRequest.dto";
+import { GetSearchPostResponse } from "src/dto/post/getSearchPostResponse.dto";
 import { AlbumService } from "src/album/service/album.service";
 import { HashTagService } from "src/hashtag/service/hashtag.service";
 import { HashTag } from "src/hashtag/hashtag.entity";
 import { Post } from "src/post/post.entity";
+import { HashTagRepository } from "src/hashtag/hashtag.repository";
 
 @Injectable()
 export class PostService {
@@ -25,6 +27,8 @@ export class PostService {
     private userRepository: UserRepository,
     @InjectRepository(AlbumRepository)
     private albumRepository: AlbumRepository,
+    @InjectRepository(HashTagRepository)
+    private hashTagRepository: HashTagRepository,
   ) {}
 
   async createPost(
@@ -153,5 +157,11 @@ export class PostService {
     this.postRepository.update(postId, { album });
 
     return "Post Shift success!!";
+  }
+
+  async getSearchPost(hashtagId: number): Promise<GetSearchPostResponse> {
+    const { posts } = await this.hashTagRepository.getSearchPosts(hashtagId);
+
+    return { posts };
   }
 }

--- a/backend/src/user/controller/user.controller.ts
+++ b/backend/src/user/controller/user.controller.ts
@@ -15,7 +15,7 @@ import { multerOption } from "src/image/service/image.service";
 @ApiTags("유저 API")
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
-@Controller("api/user")
+@Controller("user")
 export class UserController {
   constructor(private readonly userService: UserService) {}
 


### PR DESCRIPTION
## 작업 내용
- jwt accessToken 에러 처리 로직 추가
  - verify가 에러를 반환해버려서 accessToken이 만료시에 refreshToken을 검사하지 않았었다.
  - 에러 처리를 이용해 refreshToken도 검사할 수 있게 설정
- 해시태그 클릭시 리스트 조회 API 구현

## 고민한 부분
점점 리팩토링의 필요성이 보여서 조금씩 하는 중이긴 합니다...

## 리뷰 포인트
주말 순삭..

## 관련된 이슈 넘버
#146 #180 