### PR TITLE
앨범 리스트 스크롤

### DIFF
--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/index.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { useSelector } from "react-redux";
 import { RootState } from "@src/reducer";
 import Album from "./Album";
+import COLOR from "@styles/Color";
 import { useDispatch } from "react-redux";
 import { updateAlbumOrderAction, postShiftAlbumAction } from "@src/reducer/GroupReducer";
 
@@ -155,12 +156,24 @@ const AlbumList = () => {
 };
 
 const DraggableWrapper = styled.div`
-  width: 100%;
+  margin-right: 0.9rem;
   & .post-hover {
     border: 2px dotted ${(props) => props.theme.MENUTEXT};
   }
   & .album-hover {
     border-top: 1px solid ${(props) => props.theme.MENUTEXT};
+  }
+  overflow: hidden;
+  &:hover {
+    margin-right: 0.1rem;
+    overflow-y: scroll;
+    &::-webkit-scrollbar {
+      width: 0.8rem;
+    }
+    &::-webkit-scrollbar-thumb {
+      background-color: ${(props) => props.theme.SECONDARY};
+      border-radius: 1rem;
+    }
   }
 `;
 const AlbumWrapper = styled.div`


### PR DESCRIPTION
## 작업 내용
second bar에 hover했을 때 스크롤 보이게 구현
![scroll](https://user-images.githubusercontent.com/48939876/142876782-77648379-dc41-4148-b799-2d280cad0e38.gif)
이미지를 눌러야 짤이 보이네여

## 고민한 부분
grid로 영역이 나뉘어있어 hover시 스크롤이 생기면 왼쪽으로 밀리는 현상이 있었습니다.
이를 해결하기 위해 기존에 스크롤 너비만큼 margin-right을 뒀다가,
hover 시 margin-right을 삭제하고 스크롤을 보여줬습니다.

## 리뷰 포인트
감사합니다.

## 관련된 이슈 넘버
#194
