### PR TITLE
남은 API(그룹: 해시태그 전체 조회, 앨범: 포스트 검색) 연결

### DIFF
--- a/frontend/src/components/Header/Profile/Search/Recommend/index.tsx
+++ b/frontend/src/components/Header/Profile/Search/Recommend/index.tsx
@@ -24,9 +24,11 @@ const Recommend = ({ inputKeyword, setSearchKeyword, doSearch }: RecommendProps)
   };
 
   const onClickHashTag = (e: React.MouseEvent<HTMLSpanElement>) => {
-    const selectedTag = (e.target as HTMLElement).innerHTML;
-    setSearchKeyword(selectedTag);
-    doSearch(selectedTag);
+    const clicked = (e.target as HTMLElement).closest(".hashtag-wrapper");
+    if (!clicked) return;
+
+    const hashtagId = Number(clicked.getAttribute("data-id"));
+    doSearch(hashtagId);
   };
 
   useEffect(() => {
@@ -43,8 +45,8 @@ const Recommend = ({ inputKeyword, setSearchKeyword, doSearch }: RecommendProps)
         <>
           <ul>
             {recommendArray.map(({ hashtagId, hashtagContent }) => (
-              <li key={hashtagId}>
-                #<span onClick={onClickHashTag}>{hashtagContent}</span>
+              <li className="hashtag-wrapper" data-id={hashtagId} key={hashtagId} onClick={onClickHashTag}>
+                #<span>{hashtagContent}</span>
               </li>
             ))}
           </ul>

--- a/frontend/src/components/Header/Profile/Search/Recommend/index.tsx
+++ b/frontend/src/components/Header/Profile/Search/Recommend/index.tsx
@@ -1,40 +1,27 @@
-import { Dispatch, MouseEventHandler, ReactEventHandler, SetStateAction } from "react";
+import { Dispatch, SetStateAction, useState, useEffect } from "react";
 import COLOR from "@src/styles/Color";
 import styled from "styled-components";
+import { GroupType, IHashtag, requestHashtagsAction } from "@src/reducer/GroupReducer";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "@src/reducer";
+import { flexRowCenterAlign } from "@src/styles/StyledComponents";
 
 interface RecommendProps {
   inputKeyword: string;
   setSearchKeyword: Dispatch<SetStateAction<string>>;
   doSearch: Function;
 }
-interface TagType {
-  id: number;
-  name: string;
-}
 
 const Recommend = ({ inputKeyword, setSearchKeyword, doSearch }: RecommendProps) => {
-  const allTagList = [
-    { id: 0, name: "미삼집" },
-    { id: 1, name: "맥도날드" },
-    { id: 2, name: "농성화로" },
-    { id: 3, name: "아웃백" },
-    { id: 4, name: "버거킹" },
-    { id: 5, name: "롯데리아" },
-    { id: 6, name: "kfc" },
-    { id: 7, name: "포도주" },
-    { id: 8, name: "솥뚜껑" },
-    { id: 9, name: "팔팔소곱창" },
-    { id: 10, name: "청해" },
-    { id: 11, name: "맥도널드" },
-    { id: 12, name: "청헤" },
-  ];
+  const { selectedGroup, hashTags }: { selectedGroup: GroupType; hashTags: IHashtag[] } = useSelector(
+    (state: RootState) => state.groups,
+  );
+  const dispatch = useDispatch();
+  const [recommendArray, setRecommendArray] = useState<IHashtag[]>([]);
 
-  const recommendTag = (tagList: TagType[], input: string) => {
-    const recommendArray = tagList.filter((tag) => tag.name.indexOf(input) !== -1);
-    return recommendArray;
+  const recommendTag = (tagList: IHashtag[], input: string) => {
+    return tagList.filter((tag) => tag.hashtagContent.indexOf(input) !== -1);
   };
-
-  const recommendArray = recommendTag(allTagList, inputKeyword);
 
   const onClickHashTag = (e: React.MouseEvent<HTMLSpanElement>) => {
     const selectedTag = (e.target as HTMLElement).innerHTML;
@@ -42,19 +29,29 @@ const Recommend = ({ inputKeyword, setSearchKeyword, doSearch }: RecommendProps)
     doSearch(selectedTag);
   };
 
+  useEffect(() => {
+    selectedGroup && dispatch(requestHashtagsAction({ groupId: selectedGroup.groupId }));
+  }, []);
+
+  useEffect(() => {
+    setRecommendArray(recommendTag(hashTags, inputKeyword));
+  }, [hashTags, inputKeyword]);
+
   return (
     <SearchListContainer>
       {recommendArray.length > 0 ? (
         <>
           <ul>
-            {recommendArray.map(({ id, name }) => (
-              <li key={id}>
-                #<span onClick={onClickHashTag}>{name}</span>
+            {recommendArray.map(({ hashtagId, hashtagContent }) => (
+              <li key={hashtagId}>
+                #<span onClick={onClickHashTag}>{hashtagContent}</span>
               </li>
             ))}
           </ul>
         </>
-      ) : null}
+      ) : (
+        <NoResultWrapper>등록된 해시태그가 존재하지 않습니다.</NoResultWrapper>
+      )}
     </SearchListContainer>
   );
 };
@@ -93,6 +90,11 @@ const SearchListContainer = styled.div`
       }
     }
   }
+`;
+const NoResultWrapper = styled.div`
+  ${flexRowCenterAlign};
+  height: 15rem;
+  font-size: 1.6rem;
 `;
 
 export default Recommend;

--- a/frontend/src/components/Header/Profile/Search/SearchList/index.tsx
+++ b/frontend/src/components/Header/Profile/Search/SearchList/index.tsx
@@ -1,10 +1,13 @@
 import { MouseEvent, Dispatch, SetStateAction } from "react";
 import COLOR from "@src/styles/Color";
 import styled from "styled-components";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "@src/reducer";
+import { PostType } from "@src/reducer/GroupReducer";
 
 interface SearchListContent {
-  id: number;
-  name: string;
+  postId: number;
+  postTitle: string;
 }
 
 interface SearchListProps {
@@ -13,36 +16,25 @@ interface SearchListProps {
 }
 
 const SearchList = ({ setSearchKeyword, setIsSearchListOpened }: SearchListProps) => {
-  const searchListContents: SearchListContent[] = [
-    { id: 0, name: "미삼집 관련 게시글" },
-    { id: 1, name: "맥도날드 관련 게시글" },
-    { id: 2, name: "농성화로 관련 게시글" },
-    { id: 3, name: "아웃백 관련 게시글" },
-    { id: 4, name: "버거킹 관련 게시글" },
-    { id: 5, name: "롯데리아 관련 게시글" },
-    { id: 6, name: "kfc 관련 게시글" },
-    { id: 7, name: "포도주 관련 게시글" },
-    { id: 8, name: "솥뚜껑 관련 게시글" },
-    { id: 9, name: "팔팔소곱창 관련 게시글" },
-    { id: 10, name: "청해 관련 게시글" },
-  ];
+  const { searchList }: { searchList: PostType[] } = useSelector((state: RootState) => state.groups);
+  const dispatch = useDispatch();
 
-  const handleClickSearchListItem = (e: HTMLElement) => {
-    setSearchKeyword(e.innerText);
+  const onClickPost = (postId: number) => {
+    dispatch({ type: "SELECT_POST_REQUEST", postId });
     setIsSearchListOpened(false);
   };
 
   return (
     <SearchListContainer>
       <ul>
-        {searchListContents.map(({ id, name }: SearchListContent) => (
+        {searchList.map(({ postId, postTitle }: SearchListContent) => (
           <li
-            key={id}
-            onClick={(e: MouseEvent<HTMLElement>) => {
-              handleClickSearchListItem(e.target as HTMLElement);
+            key={postId}
+            onClick={() => {
+              onClickPost(postId);
             }}
           >
-            {name}
+            {postTitle}
           </li>
         ))}
       </ul>
@@ -72,6 +64,7 @@ const SearchListContainer = styled.div`
       padding: 1vh 0 1vh 1vh;
       margin: 0 1.5vw 0 0;
       border-bottom: 1px solid ${COLOR.GRAY};
+      font-size: 1.6rem;
       &:hover {
         font-weight: bold;
         cursor: pointer;

--- a/frontend/src/components/Header/Profile/Search/index.tsx
+++ b/frontend/src/components/Header/Profile/Search/index.tsx
@@ -1,29 +1,25 @@
 import { useState, ChangeEvent, KeyboardEvent } from "react";
 import COLOR from "@styles/Color";
 import styled from "styled-components";
-
 import SearchList from "@components/Header/Profile/Search/SearchList";
 import Recommend from "@components/Header/Profile/Search/Recommend";
+import { useDispatch } from "react-redux";
+import { requestPostsByHashtag } from "@src/reducer/GroupReducer";
 
 const Search = () => {
   const [searchKeyword, setSearchKeyword] = useState<string>("");
   const [isSearchListOpened, setIsSearchListOpened] = useState<Boolean>(false);
   const [isRecommendOpened, setIsRecommendOpened] = useState<Boolean>(false);
+  const dispatch = useDispatch();
 
   const handleSearchInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchKeyword(e.target.value);
   };
 
-  const handleKeyPress = (e: KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === "Enter" && searchKeyword) {
-      (document.activeElement as HTMLElement).blur();
-      doSearch(searchKeyword);
-    }
-  };
-
-  const doSearch = (key: string) => {
+  const doSearch = (hashtagId: number) => {
     setIsSearchListOpened(true);
     setIsRecommendOpened(false);
+    dispatch(requestPostsByHashtag({ hashtagId }));
   };
 
   const onFocusInput = () => {
@@ -44,7 +40,6 @@ const Search = () => {
         <SearchInput
           type="text"
           placeholder="해시태그를 입력하세요."
-          onKeyUp={handleKeyPress}
           onChange={handleSearchInputChange}
           value={searchKeyword}
           onFocus={onFocusInput}

--- a/frontend/src/reducer/GroupReducer.ts
+++ b/frontend/src/reducer/GroupReducer.ts
@@ -1,6 +1,6 @@
 import { GroupAction } from "@src/action";
 
-interface GroupType {
+export interface GroupType {
   groupId: number;
   groupName: string;
   groupImg: string;
@@ -16,6 +16,10 @@ interface AlbumListItemType {
   albumName: string;
   posts: PostType[];
   base: boolean;
+}
+export interface IHashtag {
+  hashtagId: number;
+  hashtagContent: string;
 }
 
 interface IInitState {
@@ -39,6 +43,7 @@ interface IInitState {
   postShiftAlbumLoading: boolean;
   postShiftAlbumSucceed: boolean;
   postShiftAlbumError: boolean;
+  hashTags: IHashtag[];
 }
 
 const initState: IInitState = {
@@ -62,6 +67,7 @@ const initState: IInitState = {
   postShiftAlbumLoading: false,
   postShiftAlbumSucceed: false,
   postShiftAlbumError: false,
+  hashTags: [],
 };
 
 export const CREATE_GROUP = "CREATE_GROUP";
@@ -73,7 +79,6 @@ export const GET_GROUP_LIST = "GET_GROUP_LIST";
 export const SET_GROUPS = "SET_GROUPS";
 export const REQUEST_JOIN_GROUP = "REQUEST_JOIN_GROUP";
 export const REQUEST_UPDATE_GROUP = "REQUEST_UPDATE_GROUP";
-
 export const NEW_ALBUM_REQUEST = "NEW_ALBUM_REQUEST";
 export const NEW_ALBUM_SUCCEED = "NEW_ALBUM_SUCCEED";
 export const NEW_ALBUM_FAILED = "NEW_ALBUM_FAILED";
@@ -89,6 +94,8 @@ export const UPDATE_ALBUM_ORDER_FAILED = "UPDATE_ALBUM_ORDER_FAILED";
 export const POST_SHIFT_ALBUM_REQUEST = "POST_SHIFT_ALBUM_REQUEST";
 export const POST_SHIFT_ALBUM_SUCCEED = "POST_SHIFT_ALBUM_SUCCEED";
 export const POST_SHIFT_ALBUM_FAILED = "POST_SHIFT_ALBUM_FAILED";
+export const REQUEST_HASHTAGS = "REQUEST_HASHTAGS";
+export const SET_HASHTAGS = "SET_HASHTAGS";
 
 export const createGroupAction = (payload: any) => ({
   type: CREATE_GROUP,
@@ -171,6 +178,11 @@ export const postShiftAlbumAction = (
 
 export const updateGroupAction = (payload: any) => ({
   type: REQUEST_UPDATE_GROUP,
+  payload,
+});
+
+export const requestHashtagsAction = (payload: any) => ({
+  type: REQUEST_HASHTAGS,
   payload,
 });
 
@@ -506,6 +518,11 @@ const groupReducer = (state = initState, action: any) => {
         postShiftAlbumLoading: false,
         postShiftAlbumSucceed: false,
         postShiftAlbumError: true,
+      };
+    case SET_HASHTAGS:
+      return {
+        ...state,
+        hashTags: action.payload,
       };
     default:
       return state;

--- a/frontend/src/reducer/GroupReducer.ts
+++ b/frontend/src/reducer/GroupReducer.ts
@@ -5,7 +5,7 @@ export interface GroupType {
   groupName: string;
   groupImg: string;
 }
-interface PostType {
+export interface PostType {
   postId: number;
   postTitle: string;
   postLatitude: number;
@@ -44,6 +44,7 @@ interface IInitState {
   postShiftAlbumSucceed: boolean;
   postShiftAlbumError: boolean;
   hashTags: IHashtag[];
+  searchList: PostType[];
 }
 
 const initState: IInitState = {
@@ -68,6 +69,7 @@ const initState: IInitState = {
   postShiftAlbumSucceed: false,
   postShiftAlbumError: false,
   hashTags: [],
+  searchList: [],
 };
 
 export const CREATE_GROUP = "CREATE_GROUP";
@@ -96,6 +98,7 @@ export const POST_SHIFT_ALBUM_SUCCEED = "POST_SHIFT_ALBUM_SUCCEED";
 export const POST_SHIFT_ALBUM_FAILED = "POST_SHIFT_ALBUM_FAILED";
 export const REQUEST_HASHTAGS = "REQUEST_HASHTAGS";
 export const SET_HASHTAGS = "SET_HASHTAGS";
+export const REQUEST_POSTS_BY_HASHTAG = "REQUEST_POSTS_BY_HASHTAG";
 
 export const createGroupAction = (payload: any) => ({
   type: CREATE_GROUP,
@@ -183,6 +186,11 @@ export const updateGroupAction = (payload: any) => ({
 
 export const requestHashtagsAction = (payload: any) => ({
   type: REQUEST_HASHTAGS,
+  payload,
+});
+
+export const requestPostsByHashtag = (payload: any) => ({
+  type: REQUEST_POSTS_BY_HASHTAG,
   payload,
 });
 
@@ -523,6 +531,11 @@ const groupReducer = (state = initState, action: any) => {
       return {
         ...state,
         hashTags: action.payload,
+      };
+    case "SET_SEARCHLIST":
+      return {
+        ...state,
+        searchList: action.payload.searchList,
       };
     default:
       return state;

--- a/frontend/src/sagas/group.ts
+++ b/frontend/src/sagas/group.ts
@@ -1,7 +1,7 @@
 import { all, fork, put, call, takeLatest, select, delay } from "redux-saga/effects";
 import axios from "axios";
 import { getGroupListApi } from "@src/sagas/user";
-import { SET_GROUPS } from "@src/reducer/GroupReducer";
+import { SET_GROUPS, SET_HASHTAGS } from "@src/reducer/GroupReducer";
 
 const SERVER_URL = process.env.REACT_APP_SERVER_URL;
 
@@ -93,6 +93,11 @@ async function requestUpdateGroupApi(payload: any) {
   return result;
 }
 
+async function requestHashtagsApi(payload: any) {
+  const result = await axios.get(`${SERVER_URL}/api/groups/${payload.groupId}/hashtags`, { withCredentials: true });
+  return result;
+}
+
 function* getGroupInfo(action: any) {
   try {
     const result: ResponseGenerator = yield call(getGroupInfoApi, action.payload);
@@ -167,6 +172,13 @@ function* requestUpdateGroup(action: any) {
   } catch (err) {}
 }
 
+function* requestHashtags(action: any) {
+  try {
+    const result: ResponseGenerator = yield call(requestHashtagsApi, action.payload);
+    yield put({ type: SET_HASHTAGS, payload: result.data.hashtags });
+  } catch (err) {}
+}
+
 function* watchGroupInfo() {
   yield takeLatest("REQUEST_GROUP_INFO", getGroupInfo);
 }
@@ -195,6 +207,10 @@ function* watchRequestUpdateGroup() {
   yield takeLatest("REQUEST_UPDATE_GROUP", requestUpdateGroup);
 }
 
+function* watchRequestHashtags() {
+  yield takeLatest("REQUEST_HASHTAGS", requestHashtags);
+}
+
 export default function* groupSaga() {
   yield all([
     fork(watchGroupInfo),
@@ -204,5 +220,6 @@ export default function* groupSaga() {
     fork(watchGetGroupMemberList),
     fork(watchRequestJoinGroup),
     fork(watchRequestUpdateGroup),
+    fork(watchRequestHashtags),
   ]);
 }

--- a/frontend/src/sagas/post.ts
+++ b/frontend/src/sagas/post.ts
@@ -111,6 +111,11 @@ function updatePostApi(newPost: IUpdatePost) {
   });
 }
 
+async function getPostsByHashtagApi(hashtagId: number) {
+  const result = await axios.get(`${SERVER_URL}/api/posts/search?hashtagId=${hashtagId}`, { withCredentials: true });
+  return result;
+}
+
 function* uploadPost({ post }: { type: string; post: IPost }) {
   try {
     const result: ResponseGenerator = yield call(uploadPostApi, post);
@@ -149,6 +154,16 @@ function* updatePost({ post }: { type: string; post: IUpdatePost }) {
   }
 }
 
+function* getPostsByHashtag({ type, payload }: { type: string; payload: { hashtagId: number } }) {
+  const { hashtagId } = payload;
+
+  try {
+    const result: ResponseGenerator = yield call(getPostsByHashtagApi, hashtagId);
+    const { posts } = result.data;
+    yield put({ type: "SET_SEARCHLIST", payload: { searchList: posts } });
+  } catch (err) {}
+}
+
 function* watchUploadPost() {
   yield takeEvery("UPLOAD_POST_REQUEST", uploadPost);
 }
@@ -161,7 +176,16 @@ function* watchSelectPost() {
 function* watchUpdatePost() {
   yield takeEvery("UPDATE_POST_REQUEST", updatePost);
 }
+function* watchRequestPostsByHashtag() {
+  yield takeEvery("REQUEST_POSTS_BY_HASHTAG", getPostsByHashtag);
+}
 
 export default function* userSaga() {
-  yield all([fork(watchUploadPost), fork(watchSelectPost), fork(watchUpdatePost), fork(watchDeletePost)]);
+  yield all([
+    fork(watchUploadPost),
+    fork(watchSelectPost),
+    fork(watchUpdatePost),
+    fork(watchDeletePost),
+    fork(watchRequestPostsByHashtag),
+  ]);
 }


### PR DESCRIPTION
## 작업 내용
### 해시태그 전체 조회

![video4](https://user-images.githubusercontent.com/50266862/142879154-25332149-a262-4526-86b7-44ae32537333.gif)


### 포스트 검색

![video5](https://user-images.githubusercontent.com/50266862/142879574-2bfba217-ba66-4a54-906f-c4afad94e500.gif)

- 현재 검색바는 검색어를 접두어로 일치하는 해시태그를 걸러내는 작업만 하고 있습니다.
- 결국엔 검색어로 요청하는 것이 아니라 해시태그 id로 요청을 해야 하기에, **해시태그를 클릭해야만** 해당 해시태그와 연결된 게시글들 목록이 보입니다.

## 고민한 부분


## 리뷰 포인트
- 해시태그 전체 조회 경우, 로딩을 불러와서 그리는데 시간이 좀 걸려서 이전 해시태그 리스트가 보입니다. 스피너 구현되면 적용하면 될 거 같아요.

## 관련된 이슈 넘버
#138 #186 