### PR TITLE
메인 페이지 이동시, 맨 위 그룹이 디폴트로 선택되도록 수정

### DIFF
--- a/frontend/src/components/Sidebar/FirstDepth/index.tsx
+++ b/frontend/src/components/Sidebar/FirstDepth/index.tsx
@@ -6,6 +6,7 @@ import Group from "./Group";
 import AddGroupButton from "./AddGroupButton";
 import COLOR from "@styles/Color";
 import { updateGroupOrderAction } from "@src/reducer/UserReducer";
+import { getAlbumListAction } from "@src/reducer/GroupReducer";
 
 interface FirstDepthProps {
   isToggle: boolean;
@@ -17,6 +18,11 @@ const FirstDepth = ({ isToggle, setIsToggle, addGroupBtnRef }: FirstDepthProps) 
   const { groups }: any = useSelector((state: RootState) => state.groups);
   const draggableRef = useRef<HTMLDivElement>(null);
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (!groups.length) return;
+    dispatch(getAlbumListAction(groups[0]));
+  }, [groups]);
 
   if (!groups.length) return null;
 


### PR DESCRIPTION
## 작업 내용
### 메인 페이지 로딩되면, 맨 첫 그룹 정보로 사이드바 열리도록 수정

![video6](https://user-images.githubusercontent.com/50266862/142881069-d706aaf2-bb67-42e3-8bc6-1d16263b5cce.gif)


## 관련된 이슈 넘버
#196 