### PR TITLE
해시태그 제거 시도 및 그룹 기본 이미지 지정

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,7 @@
     "@nestjs/platform-express": "^8.0.0",
     "@nestjs/swagger": "^5.1.4",
     "aws-sdk": "^2.1028.0",
-    "class-transformer": "^0.4.0",
+    "class-transformer": "0.4.0",
     "class-validator": "^0.13.1",
     "cookie-parser": "^1.4.5",
     "multer": "^1.4.3",

--- a/backend/src/dto/group/updateGroupInfoRequest.dto.ts
+++ b/backend/src/dto/group/updateGroupInfoRequest.dto.ts
@@ -1,3 +1,10 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNumber, IsNotEmpty } from "class-validator";
 import { GroupInfo } from "./groupInfo";
 
-export class UpdateGroupInfoRequestDto extends GroupInfo {}
+export class UpdateGroupInfoRequestDto extends GroupInfo {
+  @IsNumber()
+  @IsNotEmpty()
+  @ApiProperty()
+  clearImage: number;
+}

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -121,7 +121,7 @@ export class GroupService {
     const result = await this.groupRepository.leaveGroupQuery(groupId, userId);
     if (!result.affected) throw new NotFoundException("그룹에 해당 유저가 없습니다.");
 
-    const group = await this.groupRepository.findOne(groupId, { relations: ["users", "albums"] });
+    const group = await this.groupRepository.findOne(groupId, { relations: ["users"] });
     if (!group) throw new NotFoundException(`Not found group with the id ${groupId}`);
     const { users } = group;
 

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -39,7 +39,10 @@ export class GroupService {
     const { groupName } = createGroupRequestDto;
     const groupCode = await this.createInvitaionCode();
 
-    const saveObject = groupImage === undefined ? { groupName, groupCode } : { groupImage, groupName, groupCode };
+    const saveObject =
+      groupImage === undefined
+        ? { groupImage: process.env.JUSTUS_BASE_IMG, groupName, groupCode }
+        : { groupImage, groupName, groupCode };
 
     const group = await this.groupRepository.save(saveObject);
     const { groupId } = group;
@@ -105,12 +108,13 @@ export class GroupService {
     updateGroupInfoRequestDto: UpdateGroupInfoRequestDto,
   ): Promise<UpdateGroupInfoResponseDto> {
     const groupImage = this.imageService.getImageUrl(file);
-    const { groupName } = updateGroupInfoRequestDto;
+    const { groupName, clearImage } = updateGroupInfoRequestDto;
 
     const group = await this.groupRepository.findOne({ groupId });
     if (!group) throw new NotFoundException(`Not found group with the id ${groupId}`);
 
-    const updateObject = groupImage === undefined ? { groupName } : { groupImage, groupName };
+    const checkClearImage = clearImage === 1 ? { groupImage: process.env.JUSTUS_BASE_IMG, groupName } : { groupName };
+    const updateObject = groupImage === undefined ? checkClearImage : { groupImage, groupName };
 
     this.groupRepository.update(groupId, updateObject);
 

--- a/backend/src/hashtag/hashtag.entity.ts
+++ b/backend/src/hashtag/hashtag.entity.ts
@@ -11,7 +11,7 @@ export class HashTag extends TimeStampEntity {
   @Column()
   hashtagContent: string;
 
-  @ManyToMany(() => Post, { onUpdate: "CASCADE" })
+  @ManyToMany(() => Post)
   @JoinTable({ name: "posts_hashtags" })
   posts: Post[];
 

--- a/backend/src/hashtag/hashtag.repository.ts
+++ b/backend/src/hashtag/hashtag.repository.ts
@@ -1,4 +1,4 @@
-import { EntityRepository, Repository } from "typeorm";
+import { EntityRepository, Repository, DeleteResult } from "typeorm";
 import { HashTag } from "./hashtag.entity";
 
 @EntityRepository(HashTag)
@@ -9,5 +9,13 @@ export class HashTagRepository extends Repository<HashTag> {
       .select(["hashtag.hashtagId", "post.postId", "post.postTitle", "post.postDate"])
       .where("hashtag.hashtagId=:id", { id: hashtagId })
       .getOne();
+  }
+
+  async deleteHashTagsQuery(postId: number, hashtagId: number): Promise<DeleteResult> {
+    return await this.createQueryBuilder()
+      .delete()
+      .from("posts_hashtags")
+      .where("posts_post_id=:postId And hashtags_hashtag_id=:hashtagId", { postId: postId, hashtagId: hashtagId })
+      .execute();
   }
 }

--- a/backend/src/hashtag/service/hashtag.service.ts
+++ b/backend/src/hashtag/service/hashtag.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, NotFoundException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { HashTagRepository } from "../hashtag.repository";
 import { HashTag } from "../hashtag.entity";
@@ -30,6 +30,24 @@ export class HashTagService {
         }
 
         return exits;
+      }),
+    );
+  }
+
+  async deleteHashTags(hashTags: string[], postId: number): Promise<void> {
+    await Promise.all(
+      hashTags?.map(async e => {
+        const hashtag = await this.hashTagRepository.findOne({ hashtagContent: e }, { relations: ["posts"] });
+        if (!hashtag) throw new NotFoundException(`Not found hashtag with the content ${e}`);
+
+        const { hashtagId, posts } = hashtag;
+
+        await this.hashTagRepository.deleteHashTagsQuery(postId, hashtagId);
+        /* 해시태그에 연관된 게시글이 없을 때 해시태그를 지워주는 코드인데 오류 때문에 안된다. 10시간동안 붙잡고 있었지만 오류 해결을 못해서 남겨둡니다.
+        if (!posts.length) {
+          await this.hashTagRepository.softDelete(hashtag);
+        }
+        */
       }),
     );
   }

--- a/backend/src/post/post.repository.ts
+++ b/backend/src/post/post.repository.ts
@@ -1,4 +1,4 @@
-import { EntityRepository, Repository, DeleteResult } from "typeorm";
+import { EntityRepository, Repository } from "typeorm";
 import { Post } from "./post.entity";
 
 @EntityRepository(Post)
@@ -21,13 +21,5 @@ export class PostRepository extends Repository<Post> {
       ])
       .where("post.postId = :id", { id: postId })
       .getOne();
-  }
-
-  async deleteHashTagsQuery(postId: number): Promise<DeleteResult> {
-    return await this.createQueryBuilder()
-      .delete()
-      .from("posts_hashtags")
-      .where("posts_post_id=:postId", { postId: postId })
-      .execute();
   }
 }

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -1767,7 +1767,7 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
-class-transformer@^0.4.0:
+class-transformer@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.4.0.tgz#b52144117b423c516afb44cc1c76dbad31c2165b"
   integrity sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA==


### PR DESCRIPTION
## 작업 내용
- 게시글 삭제 및 수정 시 변경된 해시태그 삭제
- 그룹 기본 이미지 지정

## 고민한 부분
- 해시태그 변경
  - 6시간 동안 시도했지만 typeOrm 오류 때문에 결국 해결하지 못했습니다..
  - 오류는 post와 hashtag의 연관관계 때문에 발생하는 것 같은데 로직상으로는 post와 hashtag의 관계테이블에서 관계를 모두 삭제하고 그 이후에 hashtag 테이블에서 해당 hashtag를 삭제하게 구현했습니다.
  - 하지만 삭제시 manyTomany 관계 때문에 쿼리를 실행할 수 없다는 에러가 발생했고 방법을 찾지 못했습니다.
  - user-group 관계와 동일한 구조인데 왜 post-hashtag구조에서는 잘 안되는지 모르겠네요ㅠㅠ
- 그룹 기본 이미지 지정
  - 생성시는 이미지가 없다면 포도 이미지를 지정해줍니다.
  - 업데이트시에는 clearImage라는 변수를 body에 추가했습니다.
  - 그 이유는 현재 이미지 formdata가 없다면 현재 이미지를 유지하는 로직인데 이미지 제거를 눌러서 formdata에 이미지가 없는 경우라면 이미지 제거가 제대로 동작하지 않게 됩니다.
    - formdata에 이미지가 없으면서 clearImage가 1일 경우, 이미지 제거인 경우이므로 이미지를 기본이미지인 포도로 설정합니다.
    - formdata에 이미지가 없으면서 clearImage가 0일 경우, 이미지 변경을 하지 않고 업데이트를 하는 경우이므로 이미지는 변경되지 않습니다.
    - formdata에 이미지가 있으면 반드시 이미지를 변경하는 경우입니다.

## 리뷰 포인트
6시간을 그냥 날려버려서 커밋 수가 적습니다요...ㅠ

## 관련된 이슈 넘버
#189 