### PR TITLE
jwt payload 추가, 중복 참여 에러 추가, 이미지 url 컬럼 변경

### DIFF
--- a/backend/src/auth/guard/jwt-auth-guard.ts
+++ b/backend/src/auth/guard/jwt-auth-guard.ts
@@ -23,27 +23,28 @@ export class JwtAuthGuard extends AuthGuard("jwt") {
     const validationRefreshToken = await this.validateToken(refreshToken);
     if (!validationRefreshToken) throw new UnauthorizedException("토큰이 존재하지 않습니다.");
 
-    const { userId } = validationRefreshToken;
+    const { userId, userEmail } = validationRefreshToken;
     const accessTokenExpireTime = "1h";
-    const newAccessToken = this.createToken(userId, accessTokenExpireTime);
+    const newAccessToken = this.createToken(userId, userEmail, accessTokenExpireTime);
     response.cookie("accessToken", newAccessToken);
     request.user = validationRefreshToken;
 
     return true;
   }
 
-  async validateToken(token: string): Promise<{ userId: number }> {
+  async validateToken(token: string): Promise<{ userId: number; userEmail: string }> {
     try {
-      const { userId } = await this.jwtService.verify(token);
-      return { userId: userId };
+      const { userId, userEmail } = await this.jwtService.verify(token);
+      return { userId, userEmail };
     } catch (e) {
       return undefined;
     }
   }
 
-  createToken(userId: number, expire: string): string {
+  createToken(userId: number, userEmail: string, expire: string): string {
     const payload = {
       userId: userId,
+      userEmail: userEmail,
       userToken: "loginToken",
     };
 

--- a/backend/src/auth/service/auth.service.ts
+++ b/backend/src/auth/service/auth.service.ts
@@ -14,9 +14,10 @@ export class AuthService {
     return user;
   }
 
-  createToken(userId: number, expire: string): string {
+  createToken(userId: number, userEmail: string, expire: string): string {
     const payload = {
       userId: userId,
+      userEmail: userEmail,
       userToken: "loginToken",
     };
 

--- a/backend/src/auth/strategy/naver.strategy.ts
+++ b/backend/src/auth/strategy/naver.strategy.ts
@@ -29,12 +29,12 @@ export class NaverStrategy extends PassportStrategy(Strategy, "naver") {
     const user = await this.authService.validateUser(registerUserDto);
     if (!user) throw new UnauthorizedException("유저가 존재하지 않습니다.");
 
-    const { userId } = user;
+    const { userId, userEmail } = user;
 
     const accessTokenExpireTime = "1h";
     const refreshTokenExpireTime = "7d";
-    const accessToken = this.authService.createToken(userId, accessTokenExpireTime);
-    const refreshToken = this.authService.createToken(userId, refreshTokenExpireTime);
+    const accessToken = this.authService.createToken(userId, userEmail, accessTokenExpireTime);
+    const refreshToken = this.authService.createToken(userId, userEmail, refreshTokenExpireTime);
 
     await this.userService.updateToken(userId, refreshToken);
 

--- a/backend/src/dto/group/groupInfo.ts
+++ b/backend/src/dto/group/groupInfo.ts
@@ -1,8 +1,9 @@
-import { IsNotEmpty, IsString } from "class-validator";
-import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsOptional, IsString } from "class-validator";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 
 export class GroupInfo {
-  @ApiProperty({ type: "file" })
+  @IsOptional()
+  @ApiPropertyOptional({ type: "file" })
   groupImage: any;
 
   @IsString()

--- a/backend/src/dto/user/updateUserInfoRequest.dto.ts
+++ b/backend/src/dto/user/updateUserInfoRequest.dto.ts
@@ -1,5 +1,5 @@
-import { IsString, IsNotEmpty } from "class-validator";
-import { ApiProperty } from "@nestjs/swagger";
+import { IsString, IsNotEmpty, IsOptional } from "class-validator";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 
 export class UpdateUserInfoRequestDto {
   @IsString()
@@ -7,6 +7,7 @@ export class UpdateUserInfoRequestDto {
   @ApiProperty()
   userNickname: string;
 
-  @ApiProperty({ type: "file" })
+  @IsOptional()
+  @ApiPropertyOptional({ type: "file" })
   profileImage: any;
 }

--- a/backend/src/image/image.entity.ts
+++ b/backend/src/image/image.entity.ts
@@ -7,7 +7,7 @@ export class Image extends TimeStampEntity {
   @PrimaryGeneratedColumn()
   imageId: number;
 
-  @Column()
+  @Column({ type: "text" })
   imageUrl: string;
 
   @ManyToOne(() => Post, post => post.images, { onDelete: "CASCADE" })

--- a/backend/src/image/service/image.service.ts
+++ b/backend/src/image/service/image.service.ts
@@ -22,7 +22,8 @@ export const multerOption = {
     bucket: process.env.NCP_OBJECT_STORAGE_BUCKET,
     acl: "public-read",
     key: function (request, file, callback) {
-      const url = encodeURI(`${Date.now().toString()} - ${file.originalname}`);
+      const url = `${process.env.NCP_OBJECT_STORAGE_PATH}/${encodeURI(Date.now().toString())} - ${file.originalname}`;
+      console.log(url);
       callback(null, url);
     },
   }),

--- a/backend/src/post/service/post.service.ts
+++ b/backend/src/post/service/post.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from "@nestjs/common";
+import { Injectable, NotFoundException, UnauthorizedException } from "@nestjs/common";
 import { ImageService } from "src/image/service/image.service";
 import { InjectRepository } from "@nestjs/typeorm";
 import { PostRepository } from "../post.repository";
@@ -161,7 +161,7 @@ export class PostService {
     if (!post) throw new NotFoundException(`Not found post with the id ${postId}`);
 
     const postUserId = post.user.userId;
-    if (postUserId !== userId) throw new NotFoundException("It cannot be updated because it is not the author.");
+    if (postUserId !== userId) throw new UnauthorizedException("It cannot be updated because it is not the author.");
 
     return post;
   }

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -8,7 +8,7 @@ export class User extends TimeStampEntity {
   @PrimaryGeneratedColumn()
   userId: number;
 
-  @Column({ nullable: true })
+  @Column({ nullable: true, type: "text" })
   profileImage: string;
 
   @Column()


### PR DESCRIPTION
## 작업 내용
- jwt payload 추가
- 중복 참여 에러 추가
- 이미지 url이 길어서 저장되지 않는 현상 해결

## 고민한 부분
- jwt payload로 ID만 줬을 때 로컬과 배포 서버에서 겹치는 문제는 사실 개발할때만 발생하고 사용자 입장에서는 발생하지 않을 것 같긴하다..
  - 그래도 혹시 모르니 고유 값인 email도 추가했다.

## 리뷰 포인트
❤️

## 관련된 이슈 넘버
#217 #215 #214 