### PR TITLE
게시글 생성 모달 및 캐러셀

### DIFF
--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/Carousel/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/Carousel/index.tsx
@@ -32,28 +32,30 @@ const Carousel = ({ files, carouselWidth }: CarouselProps) => {
 
   return (
     <CarouselContainer carouselWidth={carouselWidth} className="carouselContainer">
-      <CarouselWindow>
+      <CaroselImageContainer>
         <ChangeImageButton onClick={showPrevImage} type="button" className="prevBtn">
           <img src="/icons/prev.svg" alt="go prev" height="30%"></img>
         </ChangeImageButton>
-        <CarouselImage className="carouselImage" ref={carouselRef} carouselWidth={carouselWidth}>
-          {files.map((fileObject, idx) => (
-            <div key={idx}>
-              <img
-                alt={String(fileObject)}
-                src={
-                  typeof fileObject.imageUrl === "string"
-                    ? fileObject.imageUrl
-                    : URL.createObjectURL(fileObject.imageUrl)
-                }
-              ></img>
-            </div>
-          ))}
-        </CarouselImage>
+        <CarouselWindow carouselWidth={carouselWidth}>
+          <CarouselImage className="carouselImage" ref={carouselRef} carouselWidth={carouselWidth}>
+            {files.map((fileObject, idx) => (
+              <div key={idx}>
+                <img
+                  alt={String(fileObject)}
+                  src={
+                    typeof fileObject.imageUrl === "string"
+                      ? fileObject.imageUrl
+                      : URL.createObjectURL(fileObject.imageUrl)
+                  }
+                ></img>
+              </div>
+            ))}
+          </CarouselImage>
+        </CarouselWindow>
         <ChangeImageButton onClick={showNextImage} type="button" className="nextBtn">
           <img src="/icons/next.svg" alt="go next" height="30%"></img>
         </ChangeImageButton>
-      </CarouselWindow>
+      </CaroselImageContainer>
       <DotContainer>
         {files.map((_, idx) => (
           <Dot key={idx} color={imageIndex === idx ? COLOR.BLACK : COLOR.GRAY}></Dot>
@@ -68,37 +70,49 @@ const CarouselContainer = styled.div<{ carouselWidth: number }>`
   display: grid;
   width: 100%;
   height: 100%;
+  display: flex;
   ${flexColumnCenterAlign}
 `;
-const CarouselWindow = styled.div`
-  ${flexRowCenterAlign}
+const CaroselImageContainer = styled.div`
   width: 100%;
+  height: 80%;
+  ${flexRowCenterAlign}
+`;
+const CarouselWindow = styled.div<{ carouselWidth: number }>`
+  overflow: hidden;
+  display: flex;
+  background-color: ${COLOR.WHITE};
+  width: ${(props) => props.carouselWidth}px;
+  height: 80%;
   & * {
     width: 100%;
   }
 `;
+const CarouselImage = styled.div<{ carouselWidth: number }>`
+  transform: translate3d(0, 0, 0);
+  transition: transform 0.5s;
+  display: flex;
+  justify-content: flex-start;
+  & > div {
+    ${flexRowCenterAlign}
+    background-color: ${COLOR.WHITE};
+    border: 1px solid ${COLOR.WHITE};
+    min-width: ${(props) => props.carouselWidth - 2}px;
+    max-width: ${(props) => props.carouselWidth}px;
+  }
+  & img {
+    height: ${(props) => props.carouselWidth}px;
+    object-fit: scale-down;
+  }
+`;
 const ChangeImageButton = styled.button`
   width: 10%;
+  ${flexRowCenterAlign}
   border: none;
   display: absolute;
   background: none;
   & > img {
     cursor: pointer;
-  }
-`;
-const CarouselImage = styled.div<{ carouselWidth: number }>`
-  ${flexRowCenterAlign}
-  transform: translate3d(0, 0, 0);
-  transition: transform 0.5s;
-  & div {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-  }
-  & img {
-    width: 80%;
-    object-fit: scale-down;
   }
 `;
 const DotContainer = styled.div`

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/Carousel/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/Carousel/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import COLOR from "@styles/Color";
+import { flexRowCenterAlign, flexColumnCenterAlign } from "@styles/StyledComponents";
 
 interface FileObject {
   imageUrl: File | string;
@@ -30,12 +31,12 @@ const Carousel = ({ files, carouselWidth }: CarouselProps) => {
   }, [imageIndex]);
 
   return (
-    <CarouselContainer carouselWidth={carouselWidth}>
-      <ChangeImageButton onClick={showPrevImage} type="button">
-        <img src="/icons/prev.svg" alt="go prev" height="30%"></img>
-      </ChangeImageButton>
+    <CarouselContainer carouselWidth={carouselWidth} className="carouselContainer">
       <CarouselWindow>
-        <CarouselImage ref={carouselRef} carouselWidth={carouselWidth}>
+        <ChangeImageButton onClick={showPrevImage} type="button" className="prevBtn">
+          <img src="/icons/prev.svg" alt="go prev" height="30%"></img>
+        </ChangeImageButton>
+        <CarouselImage className="carouselImage" ref={carouselRef} carouselWidth={carouselWidth}>
           {files.map((fileObject, idx) => (
             <div key={idx}>
               <img
@@ -49,10 +50,10 @@ const Carousel = ({ files, carouselWidth }: CarouselProps) => {
             </div>
           ))}
         </CarouselImage>
+        <ChangeImageButton onClick={showNextImage} type="button" className="nextBtn">
+          <img src="/icons/next.svg" alt="go next" height="30%"></img>
+        </ChangeImageButton>
       </CarouselWindow>
-      <ChangeImageButton onClick={showNextImage} type="button">
-        <img src="/icons/next.svg" alt="go next" height="30%"></img>
-      </ChangeImageButton>
       <DotContainer>
         {files.map((_, idx) => (
           <Dot key={idx} color={imageIndex === idx ? COLOR.BLACK : COLOR.GRAY}></Dot>
@@ -64,41 +65,40 @@ const Carousel = ({ files, carouselWidth }: CarouselProps) => {
 
 export default Carousel;
 const CarouselContainer = styled.div<{ carouselWidth: number }>`
-  padding: 10px;
   display: grid;
+  width: 100%;
   height: 100%;
-  grid-template-columns: 1fr ${(props) => props.carouselWidth}px 1fr;
-  grid-template-rows: 80% 20%;
-  align-items: center;
-  justify-content: center;
-`;
-const ChangeImageButton = styled.button`
-  z-index: 2;
-  height: 20%;
-  border: none;
-  background: none;
-  cursor: pointer;
+  ${flexColumnCenterAlign}
 `;
 const CarouselWindow = styled.div`
-  display: grid;
-  overflow: hidden;
-  height: 100%;
+  ${flexRowCenterAlign}
+  width: 100%;
+  & * {
+    width: 100%;
+  }
+`;
+const ChangeImageButton = styled.button`
+  width: 10%;
+  border: none;
+  display: absolute;
+  background: none;
+  & > img {
+    cursor: pointer;
+  }
 `;
 const CarouselImage = styled.div<{ carouselWidth: number }>`
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  ${flexRowCenterAlign}
   transform: translate3d(0, 0, 0);
   transition: transform 0.5s;
   & div {
     display: flex;
     justify-content: center;
     align-items: center;
-    width: ${(props) => props.carouselWidth}px;
+    width: 100%;
   }
   & img {
-    max-width: 100%;
-    object-fit: contain;
+    width: 80%;
+    object-fit: scale-down;
   }
 `;
 const DotContainer = styled.div`

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/Carousel/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/Carousel/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import COLOR from "@styles/Color";
 
@@ -15,12 +15,12 @@ const Carousel = ({ files, carouselWidth }: CarouselProps) => {
   const carouselRef = useRef<HTMLDivElement>(null);
   const [imageIndex, setImageIndex] = useState(0);
   const showNextImage = () => {
-    if (imageIndex == files.length - 1 || !carouselRef.current) return;
+    if (imageIndex === files.length - 1 || !carouselRef.current) return;
     setImageIndex(imageIndex + 1);
   };
 
   const showPrevImage = () => {
-    if (imageIndex == 0 || !carouselRef.current) return;
+    if (imageIndex === 0 || !carouselRef.current) return;
     setImageIndex(imageIndex - 1);
   };
 
@@ -32,13 +32,14 @@ const Carousel = ({ files, carouselWidth }: CarouselProps) => {
   return (
     <CarouselContainer carouselWidth={carouselWidth}>
       <ChangeImageButton onClick={showPrevImage} type="button">
-        <img src="/icons/prev.svg" alt="prev image" height="30%"></img>
+        <img src="/icons/prev.svg" alt="go prev" height="30%"></img>
       </ChangeImageButton>
       <CarouselWindow>
         <CarouselImage ref={carouselRef} carouselWidth={carouselWidth}>
           {files.map((fileObject, idx) => (
             <div key={idx}>
               <img
+                alt={String(fileObject)}
                 src={
                   typeof fileObject.imageUrl === "string"
                     ? fileObject.imageUrl
@@ -50,11 +51,11 @@ const Carousel = ({ files, carouselWidth }: CarouselProps) => {
         </CarouselImage>
       </CarouselWindow>
       <ChangeImageButton onClick={showNextImage} type="button">
-        <img src="/icons/next.svg" alt="next image" height="30%"></img>
+        <img src="/icons/next.svg" alt="go next" height="30%"></img>
       </ChangeImageButton>
       <DotContainer>
-        {files.map((fileObject, idx) => (
-          <Dot key={idx} color={imageIndex == idx ? COLOR.BLACK : COLOR.GRAY}></Dot>
+        {files.map((_, idx) => (
+          <Dot key={idx} color={imageIndex === idx ? COLOR.BLACK : COLOR.GRAY}></Dot>
         ))}
       </DotContainer>
     </CarouselContainer>
@@ -71,7 +72,18 @@ const CarouselContainer = styled.div<{ carouselWidth: number }>`
   align-items: center;
   justify-content: center;
 `;
-
+const ChangeImageButton = styled.button`
+  z-index: 2;
+  height: 20%;
+  border: none;
+  background: none;
+  cursor: pointer;
+`;
+const CarouselWindow = styled.div`
+  display: grid;
+  overflow: hidden;
+  height: 100%;
+`;
 const CarouselImage = styled.div<{ carouselWidth: number }>`
   display: flex;
   justify-content: center;
@@ -89,21 +101,6 @@ const CarouselImage = styled.div<{ carouselWidth: number }>`
     object-fit: contain;
   }
 `;
-
-const CarouselWindow = styled.div`
-  display: grid;
-  overflow: hidden;
-  height: 100%;
-`;
-
-const ChangeImageButton = styled.button`
-  z-index: 2;
-  height: 20%;
-  border: none;
-  background: none;
-  cursor: pointer;
-`;
-
 const DotContainer = styled.div`
   grid-column-start: 2;
   grid-column-end: 3;
@@ -112,7 +109,6 @@ const DotContainer = styled.div`
   justify-content: center;
   align-items: center;
 `;
-
 const Dot = styled.div`
   width: 5px;
   height: 5px;

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/ModalSub.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/ModalSub.tsx
@@ -1,7 +1,7 @@
 import styled, { keyframes } from "styled-components";
 import COLOR from "@src/styles/Color";
 import React, { useState, useEffect, Dispatch, SetStateAction } from "react";
-import { flexRowCenterAlign } from "@src/styles/StyledComponents";
+import { flexRowCenterAlign, flexColumnCenterAlign } from "@styles/StyledComponents";
 import SearchResult from "@components/Modal/PostCreateModal/UploadInfoModal/SearchResult";
 
 interface IData {
@@ -48,6 +48,8 @@ const ModalSub = ({
   setGobackClicked,
 }: ModalSubProps) => {
   const [input, setInput] = useState<string>("");
+  const SEARCH_ICON = "/icons/search.svg";
+  const SEARCH_PART_CLOSE_ICON = "/icons/arrow-left.svg";
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key !== "Enter") return;
@@ -113,7 +115,7 @@ const ModalSub = ({
     <ModalSubWrapper isToggle={isSubOpened}>
       <ModalHeader className="header-sub">
         <SearchContainer>
-          <img src="/icons/search.svg" height="90%" alt="search" />
+          <img src={SEARCH_ICON} height="90%" alt="search" />
           <SearchInput
             type="text"
             placeholder="지역명을 입력하세요."
@@ -134,7 +136,7 @@ const ModalSub = ({
         />
       )}
       <CloseBtn onClick={onClickCloseBtn} isToggle={isSubOpened}>
-        <img src="/icons/arrow-left.svg" alt="arrow left icon" />
+        <img src={SEARCH_PART_CLOSE_ICON} alt="search part close" />
       </CloseBtn>
     </ModalSubWrapper>
   );
@@ -185,28 +187,25 @@ const ModalSubWrapper = styled.div<{ isToggle: boolean }>`
 const ModalHeader = styled.div`
   display: grid;
   grid-template-columns: 10% 80% 10%;
-  padding: 1vw;
-  height: 60px;
+  height: 6rem;
   box-sizing: border-box;
-  border-bottom: 1px solid ${COLOR.GRAY};
   font-size: 1.6rem;
 `;
 const SearchContainer = styled.div`
   display: flex;
   justify-content: flex-start;
   align-items: center;
+  margin: auto;
   height: 3vh;
   width: 100%;
-  background-color: ${COLOR.WHITE};
   border-radius: 5px;
-  padding: 0.5vh 0;
   & > img {
-    padding-right: 1rem;
+    margin: 0 1rem;
   }
 `;
 const SearchInput = styled.input`
-  height: 90%;
-  min-width: 14rem;
+  min-width: 20rem;
+  min-height: 10rem;
   border: none;
   background: transparent;
   &:focus-visible {

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/SearchResult/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/SearchResult/index.tsx
@@ -62,6 +62,13 @@ const SearchResultWrapper = styled.div`
   display: flex;
   flex-direction: column;
   overflow-y: scroll;
+  &::-webkit-scrollbar {
+    width: 0.8rem;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: ${(props) => props.theme.SECONDARY};
+    border-radius: 1rem;
+  }
   height: 100%;
   box-sizing: border-box;
 `;

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/SearchResult/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/SearchResult/index.tsx
@@ -21,10 +21,10 @@ interface SearchResultProps {
 const SearchResult = ({ searchResult, setSelectedLocation, page, setPage, lastPage }: SearchResultProps) => {
   const data = searchResult;
   const searchResultWrapperRef = useRef() as React.MutableRefObject<HTMLDivElement>;
-
   const handleClickPlaceWrapper = (location: IData) => {
     setSelectedLocation({ placeName: location.place_name, x: Number(location.x), y: Number(location.y) });
   };
+  const RESULT_PLACE_ICON = "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/places_jibun.png";
 
   const handleScroll = (e: UIEvent<HTMLElement>) => {
     const target = e.target as HTMLDivElement;
@@ -48,7 +48,7 @@ const SearchResult = ({ searchResult, setSelectedLocation, page, setPage, lastPa
           <RoadAddressName>{location.road_address_name}</RoadAddressName>
           <AddressName>
             <span>
-              <img src="https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/places_jibun.png" />
+              <img src={RESULT_PLACE_ICON} alt="result place icon" />
             </span>
             {location.address_name}
           </AddressName>

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
@@ -1,6 +1,6 @@
 /*global kakao*/
 import React, { useEffect, useState, useRef, ChangeEvent } from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import COLOR from "@styles/Color";
 import { useDispatch, useSelector } from "react-redux";
 import Carousel from "@components/Modal/PostCreateModal/UploadInfoModal/Carousel";
@@ -97,11 +97,9 @@ const UploadInfoModal = ({
   };
 
   const applyHighlights = (textParam: string) => {
-    const highlightedText = textParam
-      .replace(/ /g, "<span>&nbsp;<span>")
-      .replace(/\n/g, "<br/>")
-      .replace(/#([\w|ㄱ-ㅎ|가-힣]+)/g, "<mark>$&</mark>");
-    return highlightedText;
+    const highlightedText = textParam.replace(/#([\w|ㄱ-ㅎ|가-힣]+)/g, "<mark>$&</mark>").replace(/\n/g, "<br>");
+    const addDiv = highlightedText && highlightedText.match(/\<br\>$/gm) ? `<div class="new-line"></div>` : ``;
+    return highlightedText + addDiv;
   };
 
   const handleScroll = () => {
@@ -185,8 +183,9 @@ const UploadInfoModal = ({
           <ModalRight className="modalRight">
             <InputTitle type="text" placeholder="제목" value={title} onChange={handelTitleInput} />
             <ContentWrap className="contentWrap">
-              <BackDrop className="backdrop" ref={backdropRef}></BackDrop>
-              <HighLights ref={highlightsRef} className="highlights"></HighLights>
+              <BackDrop className="backdrop" ref={backdropRef}>
+                <HighLights ref={highlightsRef} className="highlights"></HighLights>
+              </BackDrop>
               <InputText
                 ref={inputRef}
                 placeholder="내용"
@@ -310,14 +309,28 @@ const ContentWrap = styled.div`
   position: relative;
   width: 100%;
 `;
-const BackDrop = styled.div`
-  height: 20rem;
-  position: absolute;
-  width: 100%;
-  word-break: break-all;
-  overflow-y: scroll;
+const contentOverflow = css`
+  word-break: normal;
+  overflow-wrap: break-word;
+`;
+const contentWhiteSpace = css`
+  white-space: pre-wrap;
+`;
+const contentFont = css`
   font-size: 1.6rem;
   line-height: 2rem;
+`;
+const contentSize = css`
+  height: 20rem;
+  width: 100%;
+`;
+const BackDrop = styled.div`
+  ${contentOverflow}
+  ${contentWhiteSpace}
+  ${contentFont}
+  ${contentSize}
+  position: absolute;
+  overflow-y: scroll;
   &::-webkit-scrollbar {
     width: 0.8rem;
   }
@@ -327,29 +340,25 @@ const BackDrop = styled.div`
   }
 `;
 const HighLights = styled.div`
-  height: 20rem;
+  ${contentOverflow}
+  ${contentWhiteSpace}
+  ${contentFont}
+  ${contentSize}
   position: absolute;
-  width: 100%;
-  word-break: break-all;
   overflow-y: scroll;
-  font-size: 1.6rem;
-  line-height: 2rem;
   &::-webkit-scrollbar {
-    width: 0.8rem;
-  }
-  &::-webkit-scrollbar-thumb {
-    background-color: ${(props) => props.theme.SECONDARY};
-    border-radius: 1rem;
+    width: 0;
   }
 `;
 const InputText = styled.textarea`
-  height: 20rem;
+  ${contentOverflow}
+  ${contentWhiteSpace}
+  ${contentFont}
+  ${contentSize}
+  resize: none;
+  border: none;
   position: relative;
-  width: 100%;
-  word-break: break-all;
   overflow-y: scroll;
-  font-size: 1.6rem;
-  line-height: 2rem;
   &::-webkit-scrollbar {
     width: 0.8rem;
   }
@@ -367,12 +376,14 @@ const ModalRight = styled.div`
   flex-direction: column;
   height: 100%;
   & mark {
-    border-radius: 3px;
-    color: transparent;
+    ${contentOverflow}
+    ${contentWhiteSpace}
+    ${contentFont}
+    display: inline;
     background-color: ${COLOR.THEME1.SECONDARY};
-    letter-spacing: normal;
-    font-size: 1.6rem;
-    overflow: auto;
+  }
+  & .new-line {
+    height: 2rem;
   }
 `;
 const ModalLeft = styled.div`

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
@@ -416,6 +416,11 @@ const InputBottom = styled.div`
   align-items: flex-end;
   border-top: 1px solid ${COLOR.LIGHTGRAY1};
   min-height: 10rem;
+  & > input[type="date"] {
+    font-family: "NanumGothic", sans-serif;
+    overflow: hidden;
+    padding: 0;
+  }
 `;
 const InputDate = styled.input`
   flex-basis: 20vh;

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 import Carousel from "@components/Modal/PostCreateModal/UploadInfoModal/Carousel";
 import { RootState } from "@src/reducer";
 import ModalSub from "./ModalSub";
+import { flexRowCenterAlign } from "@styles/StyledComponents";
 
 interface FileObject {
   imageUrl: File | string;
@@ -164,9 +165,10 @@ const UploadInfoModal = ({
         event.nativeEvent.stopImmediatePropagation();
       }}
       isSubOpened={isSubOpened}
+      className="modalContainer"
     >
-      <ModalMain isSubOpened={isSubOpened}>
-        <ModalHeader>
+      <ModalMain isSubOpened={isSubOpened} className="modalMain">
+        <ModalHeader className="modalHeader">
           <ModalTitle>{mode === "create" ? "새 게시물 만들기" : "게시물 수정"}</ModalTitle>
           <ModalHeaderRigthBtn onClick={closeModal}>
             <img src="/icons/x.svg" alt="close"></img>
@@ -255,6 +257,14 @@ const contentSize = css`
   height: 20rem;
   width: 100%;
 `;
+const headerBtn = css`
+  ${flexRowCenterAlign}
+  border: none;
+  background: none;
+  & > img {
+    cursor: pointer;
+  }
+`;
 const ModalContainer = styled.div<{ isSubOpened: boolean }>`
   display: flex;
   flex-direction: row;
@@ -278,53 +288,38 @@ const ModalMain = styled.div<{ isSubOpened: boolean }>`
 const ModalHeader = styled.div`
   display: grid;
   grid-template-columns: 10% 80% 10%;
-  height: 60px;
+  height: 6rem;
   box-sizing: border-box;
-  font-size: max(1.2vw, 20px);
+  position: relative;
 `;
 const ModalTitle = styled.div`
+  ${flexRowCenterAlign}
   grid-column-start: 2;
   grid-column-end: 3;
   grid-row-start: 1;
   grid-row-end: 2;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
   font-size: 2.5rem;
 `;
 const ModalHeaderLeftBtn = styled.button`
-  grid-column-start: 1;
-  grid-column-end: 2;
-  grid-row-start: 1;
-  grid-row-end: 2;
-  border: none;
-  background: none;
-  cursor: pointer;
+  ${headerBtn}
 `;
 const ModalHeaderRigthBtn = styled.button`
-  grid-column-start: 3;
-  grid-column-end: 4;
-  grid-row-start: 1;
-  grid-row-end: 2;
-  border: none;
-  background: none;
-  cursor: pointer;
+  ${headerBtn}
 `;
 const ModalContent = styled.div`
   display: grid;
-  height: 100%;
+  position: relative;
   grid-template-columns: 50% 50%;
   box-sizing: border-box;
 `;
 const ModalLeft = styled.div`
+  position: relative;
   width: 100%;
-  height: 45vh;
 `;
 const ModalRight = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
-  height: 100%;
   & mark {
     ${contentOverflow}
     ${contentWhiteSpace}
@@ -335,10 +330,17 @@ const ModalRight = styled.div`
   & .new-line {
     height: 2rem;
   }
+  & > * {
+    margin-top: 1rem;
+    &:first-child {
+      margin: 0;
+    }
+  }
 `;
 const InputTitle = styled.input`
   flex-basis: 5vh;
   border: none;
+  background-color: transparent;
   border-bottom: 1px solid ${COLOR.LIGHTGRAY1};
   font-size: 1.6rem;
   &:focus {
@@ -434,7 +436,10 @@ const InputPlaceName = styled.div`
 const LocationButton = styled.button`
   border: none;
   background: none;
-  cursor: pointer;
+  & > img {
+    ${flexRowCenterAlign}
+    cursor: pointer;
+  }
 `;
 const UploadButton = styled.button<{ activate: boolean }>`
   background-color: ${(props) => {

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 import Carousel from "@components/Modal/PostCreateModal/UploadInfoModal/Carousel";
 import { RootState } from "@src/reducer";
 import ModalSub from "./ModalSub";
-import { flexRowCenterAlign } from "@styles/StyledComponents";
+import { flexRowCenterAlign, flexColumnCenterAlign } from "@styles/StyledComponents";
 
 interface FileObject {
   imageUrl: File | string;
@@ -269,8 +269,10 @@ const ModalContainer = styled.div<{ isSubOpened: boolean }>`
   display: flex;
   flex-direction: row;
   background-color: ${COLOR.WHITE};
-  min-width: 40vw;
-  height: 55rem;
+  /* min-width: 40%; */
+  width: 50%;
+  /* height: 60%; */
+  /* min-height: 50rem; */
   border-radius: 1rem;
   box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
 
@@ -302,6 +304,7 @@ const ModalTitle = styled.div`
 `;
 const ModalHeaderLeftBtn = styled.button`
   ${headerBtn}
+  ${flexColumnCenterAlign}
 `;
 const ModalHeaderRigthBtn = styled.button`
   ${headerBtn}
@@ -311,10 +314,12 @@ const ModalContent = styled.div`
   position: relative;
   grid-template-columns: 50% 50%;
   box-sizing: border-box;
+  margin: 0 1rem 1.5rem;
 `;
 const ModalLeft = styled.div`
   position: relative;
   width: 100%;
+  height: 100%;
 `;
 const ModalRight = styled.div`
   position: relative;

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
@@ -177,7 +177,7 @@ const UploadInfoModal = ({
             <img src="/icons/prev.svg" alt="prev modal"></img>
           </ModalHeaderLeftBtn>
         </ModalHeader>
-        <ModalContent>
+        <ModalContent className="modalContent">
           <ModalLeft className="modalLeft">
             <Carousel files={files} carouselWidth={250} />
           </ModalLeft>
@@ -269,10 +269,8 @@ const ModalContainer = styled.div<{ isSubOpened: boolean }>`
   display: flex;
   flex-direction: row;
   background-color: ${COLOR.WHITE};
-  /* min-width: 40%; */
-  width: 50%;
-  /* height: 60%; */
-  /* min-height: 50rem; */
+  height: 60%;
+  min-height: 480px;
   border-radius: 1rem;
   box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
 
@@ -283,14 +281,15 @@ const ModalContainer = styled.div<{ isSubOpened: boolean }>`
 const ModalMain = styled.div<{ isSubOpened: boolean }>`
   display: flex;
   flex-direction: column;
-  min-width: ${(props) => (props.isSubOpened ? "40vw" : "40vw")};
+  min-width: 720px;
   height: 100%;
   z-index: 6;
+  display: grid;
+  grid-template-rows: 10% 90%;
 `;
 const ModalHeader = styled.div`
   display: grid;
   grid-template-columns: 10% 80% 10%;
-  height: 6rem;
   box-sizing: border-box;
   position: relative;
 `;
@@ -314,17 +313,22 @@ const ModalContent = styled.div`
   position: relative;
   grid-template-columns: 50% 50%;
   box-sizing: border-box;
-  margin: 0 1rem 1.5rem;
+  margin: 0 2rem 2rem 1rem;
+  height: 100%;
 `;
 const ModalLeft = styled.div`
   position: relative;
   width: 100%;
-  height: 100%;
+  height: 90%;
+  min-width: 300px;
+  margin-right: 2rem;
 `;
 const ModalRight = styled.div`
   position: relative;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  height: 90%;
+  margin-left: 2rem;
+  grid-template-rows: 10% 40% 30% 10%;
   & mark {
     ${contentOverflow}
     ${contentWhiteSpace}

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
@@ -240,74 +240,6 @@ const UploadInfoModal = ({
   );
 };
 
-const UploadButton = styled.button<{ activate: boolean }>`
-  background-color: ${(props) => {
-    if (props.activate) return props.theme.PRIMARY;
-    else return props.theme.SECONDARY;
-  }};
-  border: none;
-  border-radius: 1rem;
-  flex-basis: 3rem;
-  color: ${COLOR.WHITE};
-  font-size: 1.6rem;
-  cursor: ${(props) => {
-    if (props.activate) return "pointer";
-    else return "not-allowed";
-  }};
-`;
-const LocationButton = styled.button`
-  border: none;
-  background: none;
-  cursor: pointer;
-`;
-const InputPlaceName = styled.div`
-  border: 1px solid black;
-  height: 4vh;
-  line-height: 4vh;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  border: none;
-  margin-right: 3rem;
-  flex-basis: 90%;
-  text-align: right;
-  color: ${COLOR.DARKGRAY};
-  font-size: 1.6rem;
-`;
-const InputBottom = styled.div`
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  max-height: 5rem;
-  justify-content: space-between;
-  align-items: flex-end;
-  border-top: 1px solid ${COLOR.LIGHTGRAY1};
-  min-height: 10rem;
-`;
-const InputPlace = styled.div`
-  display: flex;
-  width: 100%;
-  z-index: 3;
-`;
-const InputDate = styled.input`
-  flex-basis: 20vh;
-  border: none;
-  font-size: 1.6rem;
-  z-index: 3;
-`;
-const InputTitle = styled.input`
-  flex-basis: 5vh;
-  border: none;
-  border-bottom: 1px solid ${COLOR.LIGHTGRAY1};
-  font-size: 1.6rem;
-  &:focus {
-    outline: none;
-  }
-`;
-const ContentWrap = styled.div`
-  position: relative;
-  width: 100%;
-`;
 const contentOverflow = css`
   word-break: normal;
   overflow-wrap: break-word;
@@ -321,6 +253,100 @@ const contentFont = css`
 `;
 const contentSize = css`
   height: 20rem;
+  width: 100%;
+`;
+const ModalContainer = styled.div<{ isSubOpened: boolean }>`
+  display: flex;
+  flex-direction: row;
+  background-color: ${COLOR.WHITE};
+  min-width: 40vw;
+  height: 55rem;
+  border-radius: 1rem;
+  box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+const ModalMain = styled.div<{ isSubOpened: boolean }>`
+  display: flex;
+  flex-direction: column;
+  min-width: ${(props) => (props.isSubOpened ? "40vw" : "40vw")};
+  height: 100%;
+  z-index: 6;
+`;
+const ModalHeader = styled.div`
+  display: grid;
+  grid-template-columns: 10% 80% 10%;
+  height: 60px;
+  box-sizing: border-box;
+  font-size: max(1.2vw, 20px);
+`;
+const ModalTitle = styled.div`
+  grid-column-start: 2;
+  grid-column-end: 3;
+  grid-row-start: 1;
+  grid-row-end: 2;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  font-size: 2.5rem;
+`;
+const ModalHeaderLeftBtn = styled.button`
+  grid-column-start: 1;
+  grid-column-end: 2;
+  grid-row-start: 1;
+  grid-row-end: 2;
+  border: none;
+  background: none;
+  cursor: pointer;
+`;
+const ModalHeaderRigthBtn = styled.button`
+  grid-column-start: 3;
+  grid-column-end: 4;
+  grid-row-start: 1;
+  grid-row-end: 2;
+  border: none;
+  background: none;
+  cursor: pointer;
+`;
+const ModalContent = styled.div`
+  display: grid;
+  height: 100%;
+  grid-template-columns: 50% 50%;
+  box-sizing: border-box;
+`;
+const ModalLeft = styled.div`
+  width: 100%;
+  height: 45vh;
+`;
+const ModalRight = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  & mark {
+    ${contentOverflow}
+    ${contentWhiteSpace}
+    ${contentFont}
+    display: inline;
+    background-color: ${COLOR.THEME1.SECONDARY};
+  }
+  & .new-line {
+    height: 2rem;
+  }
+`;
+const InputTitle = styled.input`
+  flex-basis: 5vh;
+  border: none;
+  border-bottom: 1px solid ${COLOR.LIGHTGRAY1};
+  font-size: 1.6rem;
+  &:focus {
+    outline: none;
+  }
+`;
+const ContentWrap = styled.div`
+  position: relative;
   width: 100%;
 `;
 const BackDrop = styled.div`
@@ -370,87 +396,60 @@ const InputText = styled.textarea`
     outline: none;
   }
 `;
-const ModalRight = styled.div`
+const InputBottom = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
-  height: 100%;
-  & mark {
-    ${contentOverflow}
-    ${contentWhiteSpace}
-    ${contentFont}
-    display: inline;
-    background-color: ${COLOR.THEME1.SECONDARY};
-  }
-  & .new-line {
-    height: 2rem;
-  }
+  max-height: 5rem;
+  justify-content: space-between;
+  align-items: flex-end;
+  border-top: 1px solid ${COLOR.LIGHTGRAY1};
+  min-height: 10rem;
 `;
-const ModalLeft = styled.div`
+const InputDate = styled.input`
+  flex-basis: 20vh;
+  border: none;
+  font-size: 1.6rem;
+  z-index: 3;
+`;
+const InputPlace = styled.div`
+  display: flex;
   width: 100%;
-  height: 45vh;
+  z-index: 3;
 `;
-const ModalContent = styled.div`
-  display: grid;
-  height: 100%;
-  grid-template-columns: 50% 50%;
-  box-sizing: border-box;
+const InputPlaceName = styled.div`
+  border: 1px solid black;
+  height: 4vh;
+  line-height: 4vh;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border: none;
+  margin-right: 3rem;
+  flex-basis: 90%;
+  text-align: right;
+  color: ${COLOR.DARKGRAY};
+  font-size: 1.6rem;
 `;
-const ModalContainer = styled.div<{ isSubOpened: boolean }>`
-  display: flex;
-  flex-direction: row;
-  background-color: ${COLOR.WHITE};
-  min-width: 40vw;
-  height: 55rem;
+const LocationButton = styled.button`
+  border: none;
+  background: none;
+  cursor: pointer;
+`;
+const UploadButton = styled.button<{ activate: boolean }>`
+  background-color: ${(props) => {
+    if (props.activate) return props.theme.PRIMARY;
+    else return props.theme.SECONDARY;
+  }};
+  border: none;
   border-radius: 1rem;
-  box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
-`;
-const ModalMain = styled.div<{ isSubOpened: boolean }>`
-  display: flex;
-  flex-direction: column;
-  min-width: ${(props) => (props.isSubOpened ? "40vw" : "40vw")};
-  height: 100%;
-  z-index: 6;
-`;
-
-const ModalHeaderLeftBtn = styled.button`
-  grid-column-start: 1;
-  grid-column-end: 2;
-  grid-row-start: 1;
-  grid-row-end: 2;
-  border: none;
-  background: none;
-  cursor: pointer;
-`;
-const ModalHeaderRigthBtn = styled.button`
-  grid-column-start: 3;
-  grid-column-end: 4;
-  grid-row-start: 1;
-  grid-row-end: 2;
-  border: none;
-  background: none;
-  cursor: pointer;
-`;
-const ModalHeader = styled.div`
-  display: grid;
-  grid-template-columns: 10% 80% 10%;
-  height: 60px;
-  box-sizing: border-box;
-  font-size: max(1.2vw, 20px);
-`;
-const ModalTitle = styled.div`
-  grid-column-start: 2;
-  grid-column-end: 3;
-  grid-row-start: 1;
-  grid-row-end: 2;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  font-size: 2.5rem;
+  flex-basis: 3rem;
+  color: ${COLOR.WHITE};
+  font-size: 1.6rem;
+  cursor: ${(props) => {
+    if (props.activate) return "pointer";
+    else return "not-allowed";
+  }};
 `;
 
 export default UploadInfoModal;

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
@@ -1,5 +1,4 @@
-/*global kakao*/
-import React, { useEffect, useState, useRef, ChangeEvent } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import styled, { css } from "styled-components";
 import COLOR from "@styles/Color";
 import { useDispatch, useSelector } from "react-redux";
@@ -168,7 +167,7 @@ const UploadInfoModal = ({
     >
       <ModalMain isSubOpened={isSubOpened}>
         <ModalHeader>
-          <ModalTitle>{mode == "create" ? "새 게시물 만들기" : "게시물 수정"}</ModalTitle>
+          <ModalTitle>{mode === "create" ? "새 게시물 만들기" : "게시물 수정"}</ModalTitle>
           <ModalHeaderRigthBtn onClick={closeModal}>
             <img src="/icons/x.svg" alt="close"></img>
           </ModalHeaderRigthBtn>
@@ -212,12 +211,12 @@ const UploadInfoModal = ({
                   <InputPlaceName>{address}</InputPlaceName>
                 )}
                 <LocationButton onClick={address === "" ? onClickLocationBtn : () => null}>
-                  <img src="/icons/location.svg" width="100%" />
+                  <img src="/icons/location.svg" alt="location" width="100%" />
                 </LocationButton>
               </InputPlace>
             </InputBottom>
             <UploadButton activate={activate} onClick={handleSaveBtn}>
-              {mode == "create" ? "게시하기" : "수정하기"}
+              {mode === "create" ? "게시하기" : "수정하기"}
             </UploadButton>
           </ModalRight>
         </ModalContent>

--- a/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
+++ b/frontend/src/components/Modal/PostCreateModal/UploadInfoModal/index.tsx
@@ -270,7 +270,7 @@ const ModalContainer = styled.div<{ isSubOpened: boolean }>`
   flex-direction: row;
   background-color: ${COLOR.WHITE};
   height: 60%;
-  min-height: 480px;
+  min-height: 460px;
   border-radius: 1rem;
   box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
 
@@ -328,7 +328,7 @@ const ModalRight = styled.div`
   display: grid;
   height: 90%;
   margin-left: 2rem;
-  grid-template-rows: 10% 40% 30% 10%;
+  grid-template-rows: 15% 40% 30% 15%;
   & mark {
     ${contentOverflow}
     ${contentWhiteSpace}


### PR DESCRIPTION
## 작업 내용
사진을 누르시면 gif 실행이 됩니다:)

밀림 현상 제거
![밀림현상제거](https://user-images.githubusercontent.com/48939876/143047912-80d06912-a104-492c-9c10-bcba42849a0c.gif)
세로로 긴 사진을 첨부했을 때 잘리는 현상 해결
![캐러셀](https://user-images.githubusercontent.com/48939876/143047919-4b8fcc3e-57a2-437d-bbc0-b010a2cb04d3.gif)
date picker 글꼴 설정 및 장소 스크롤 구현
![날짜및장소](https://user-images.githubusercontent.com/48939876/143047933-a0362947-6830-4c86-9466-5efab93cabb2.gif)

## 고민한 부분
### 밀림 현상 제거
밀림 현상이 생기는 원인은 글을 작성하는 textarea, 해당 글에서 해시태그(#으로 시작하는 단어)를 찾아 배경 색을 넣어줄 backdrop, highlights태그를 사용함에 따라 둘의 싱크 혹은 크기가 맞지 않아 생기는 오류였습니다.
일단 크기를 맞춰주고 다른 css 속성(word-break, overflow)을 동일하게 하기 위해 styled-component의 변수를 사용해서 속성을 동일하게 맞춰줬습니다.
다음으로 싱크가 맞지 않는 구간을 찾아야했는데, 줄바꿈 시 css의 pre속성을 이용하지만 맨 마지막에 enter를 누르는 경우 backdrop, highlights태그(div태그)에서는 br태그가 textarea처럼 한 줄 만큼의 영역을 차지하지 않아서 생기는 오류였습니다.
이를 해결해주기 위해 마지막에 br태그가 존재하는 경우를 정규식으로 찾아서 마지막 br태그만 div태그를 새로 생성해서 line-height인 2rem만큼만 영역을 차지하게 해서 해결했습니다.
이를 수정하면서 input textarea의 영역도 fix해주었습니다. (게시글 생성할 때 게시글 내용 많이 쓰면 모달 크기가 양옆으로 늘어나는 현상 제거)

### 캐러셀
캐러셀의 경우 div태그 내에 img태그가 존재하는데, img태그의 속성 중 object-fit을 scale-down으로 수정(기존에는 contain)하고, img태그를 감싸는 div태그의 height와 width를 캐러셀 가로만큼으로 수정하여 세로로 긴 사진이 잘리는 현상을 수정했습니다.

이 외 string으로 사용한 값들을 상수화 시키고, img태그에 alt속성을 추가하는 작업을 진행했습니다.

## 리뷰 포인트
수고하셨습니다 :)
참고로 아직 게시글 관련 css를 진행할 예정이라 현재 사용중인 styled-component 태그에 className을 달아놓은 상태입니다.
작업이 끝나는대로 해당 className을 제거하도록 하겠습니다.

## 관련된 이슈 넘버
#192 #193