### PR TITLE
디자인 CSS 수정

### DIFF
--- a/frontend/src/components/Header/Profile/Modal/ProfileModal.tsx
+++ b/frontend/src/components/Header/Profile/Modal/ProfileModal.tsx
@@ -71,7 +71,7 @@ const Container = styled.div`
   font-size: 2rem;
 
   & li {
-    padding-bottom: 2rem;
+    padding: 1rem 0;
 
     &:hover {
       font-weight: bold;

--- a/frontend/src/components/Header/Profile/Search/index.tsx
+++ b/frontend/src/components/Header/Profile/Search/index.tsx
@@ -83,7 +83,7 @@ const SearchContainer = styled.div`
 
 const SearchInput = styled.input`
   height: 100%;
-  width: 80%;
+  width: 100%;
   border: none;
   &:focus-visible {
     outline: none;

--- a/frontend/src/components/Header/Profile/index.tsx
+++ b/frontend/src/components/Header/Profile/index.tsx
@@ -8,7 +8,9 @@ import COLOR from "@src/styles/Color";
 const Profile = () => {
   const dispatch = useDispatch();
   const { isProfileWrapperModalOpened } = useSelector((state: RootState) => state.modal);
-  const { userProfile, userNickName } = useSelector((state: RootState) => state.user);
+  const { userProfile, userNickName }: { userProfile: string; userNickName: string } = useSelector(
+    (state: RootState) => state.user,
+  );
   const { clickedTarget } = useSelector((state: RootState) => state.groupModal);
 
   const handleProfileBtnClick = () => {
@@ -22,9 +24,17 @@ const Profile = () => {
 
   return (
     <>
-      <ProfileContainer id="profile" onClick={handleProfileBtnClick}>
-        <ProfileName>{userNickName}</ProfileName>
-        <ProfileImage profile={userProfile}></ProfileImage>
+      <ProfileContainer>
+        <ProfileContent id="profile" onClick={handleProfileBtnClick}>
+          <ProfileName>
+            {userNickName
+              ? userNickName.length > 10
+                ? userNickName.substring(0, 10).concat("...")
+                : userNickName
+              : ""}
+          </ProfileName>
+          <ProfileImage profile={userProfile}></ProfileImage>
+        </ProfileContent>
       </ProfileContainer>
       {isProfileWrapperModalOpened && <ProfileModal />}
     </>
@@ -41,6 +51,9 @@ const ProfileContainer = styled.div`
   width: 100%;
   display: flex;
   justify-content: flex-end;
+`;
+const ProfileContent = styled.div`
+  display: flex;
   align-items: center;
 `;
 const ProfileImage = styled.button<{ profile: string }>`

--- a/frontend/src/components/Modal/PostShowModal/PostInfoModal.tsx
+++ b/frontend/src/components/Modal/PostShowModal/PostInfoModal.tsx
@@ -57,7 +57,11 @@ const PostInfoModal = () => {
     >
       <Modal>
         <ModalHeader>
-          <PostTitle>{selectedPost.postTitle}</PostTitle>
+          <PostTitle>
+            {selectedPost.postTitle.length > 20
+              ? selectedPost.postTitle.substring(0, 20).concat("...")
+              : selectedPost.postTitle}
+          </PostTitle>
           {selectedPost.userId === userId ? (
             <MoreIconWrapper
               className="more-icon"

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Header/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Header/index.tsx
@@ -35,7 +35,7 @@ const Header = ({ albumId, albumName, postToggle, setPostToggle, AlbumDragHandle
         {postToggle && <ArrowDownSVG fill={nowTheme.MENUTEXT} />}
         {!postToggle && <ArrowRightSVG fill={nowTheme.MENUTEXT} />}
       </ArrowIcon>
-      <AlbumNameWrapper>
+      <AlbumNameWrapper onClick={onClickArrowDown}>
         <AlbumName>{albumName}</AlbumName>
       </AlbumNameWrapper>
       {albumName !== "기본 앨범" && (

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -84,6 +84,10 @@ const LeftSide = styled.div`
   flex-direction: column;
   justify-content: space-between;
   height: 300px;
+
+  & > a {
+    width: 350px;
+  }
 `;
 
 const Logo = styled.div`


### PR DESCRIPTION
## 작업 내용
눈에 바로 띄는 보완해 줄 만한 디자인을 수정해봤습니다.
- 로그인 버튼이랑 a 태그랑 너비 같도록 수정
- 헤더 프로필 클릭 범위 수정 & 닉네임 길이 제한
- 게시글 조회 모달에 보여지는 제목 글자 제한
- 앨범명 눌러도 앨범 열고 닫히도록 수정
- 헤더의 해시태그 입력란 100%로 확장
- 프로필 클릭시 모달, 아래 패딩을 위아래 패딩으로 변경
