### PR TITLE
게시글 트랜잭션 처리

### DIFF
--- a/backend/src/hashtag/service/hashtag.service.ts
+++ b/backend/src/hashtag/service/hashtag.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { HashTagRepository } from "../hashtag.repository";
 import { HashTag } from "../hashtag.entity";
 import { GroupRepository } from "src/group/group.repository";
+import { QueryRunner } from "typeorm";
 
 @Injectable()
 export class HashTagService {
@@ -15,6 +16,7 @@ export class HashTagService {
 
   async makeHashTag(groupId: number, hashTags: string[]): Promise<HashTag[]> {
     const group = await this.groupRepository.findOne(groupId);
+    if (!group) throw new NotFoundException(`Not found group with the id ${groupId}`);
 
     return await Promise.all(
       hashTags?.map(async e => {
@@ -34,18 +36,26 @@ export class HashTagService {
     );
   }
 
-  async deleteHashTags(hashTags: string[], postId: number): Promise<void> {
+  async deleteHashTags(hashTags: string[], postId: number, queryRunner: QueryRunner): Promise<void> {
     await Promise.all(
       hashTags?.map(async e => {
-        const hashtag = await this.hashTagRepository.findOne({ hashtagContent: e }, { relations: ["posts"] });
+        const hashtag = await queryRunner.manager
+          .getCustomRepository(HashTagRepository)
+          .findOne({ hashtagContent: e }, { relations: ["posts"] });
         if (!hashtag) throw new NotFoundException(`Not found hashtag with the content ${e}`);
 
-        const { hashtagId, posts } = hashtag;
+        const { hashtagId } = hashtag;
 
-        await this.hashTagRepository.deleteHashTagsQuery(postId, hashtagId);
+        await queryRunner.manager.getCustomRepository(HashTagRepository).deleteHashTagsQuery(postId, hashtagId);
+
         /* 해시태그에 연관된 게시글이 없을 때 해시태그를 지워주는 코드인데 오류 때문에 안된다. 10시간동안 붙잡고 있었지만 오류 해결을 못해서 남겨둡니다.
+        const lastposts = await queryRunner.manager
+          .getCustomRepository(HashTagRepository)
+          .findOne(hashtagId, { relations: ["posts"] });
+        const { posts } = lastposts;
+
         if (!posts.length) {
-          await this.hashTagRepository.softDelete(hashtag);
+          await queryRunner.manager.getCustomRepository(HashTagRepository).softDelete(hashtag);
         }
         */
       }),


### PR DESCRIPTION
## 작업 내용
- 게시글 업데이트, 삭제 트랜잭션 처리

## 고민한 부분
- 연결한 트랜잭션 매니저로 모든 db작업을 수행해야되기 때문에 인자로 매니저를 계속 넘겨주어야 했습니다.
- get같은 경우는 if로 처리가 가능해서 미리 처리할 수 있는 get 요청은 트랜잭션 전에 처리를 해주고 어쩔 수 없이 트랜잭션 안에서 처리해야하는 get 요청은 동일하게 트랜잭션 처리를 해주었습니다.

## 리뷰 포인트
- 기존에 db처리중 중간에 실패하면 이전에 실행한 db는 실행이 되었었는데 트랜잭션 처리를 하고 나니 실패하면 try-catch 에 있는 모든 db작업은 롤백됩니당

## 관련된 이슈 넘버
#226 