### PR TITLE
토스트 메세지 보완

### DIFF
--- a/frontend/src/components/Header/Profile/Modal/InnerModal/UserInfoModal.tsx
+++ b/frontend/src/components/Header/Profile/Modal/InnerModal/UserInfoModal.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import styled, { keyframes } from "styled-components";
 import Modal from "@components/Modal";
 import { useDispatch } from "react-redux";
 import COLOR from "@styles/Color";
 import { flexRowCenterAlign } from "@src/styles/StyledComponents";
-import { userInfoUpdateAction, SET_UPDATED_INIT } from "@src/reducer/UserReducer";
+import { userInfoUpdateAction } from "@src/reducer/UserReducer";
 import { useSelector } from "react-redux";
 import { RootState } from "@src/reducer";
 import { SET_ERROR_TOAST } from "@src/reducer/ToastReducer";
@@ -14,7 +14,7 @@ const UserInfoModal = () => {
   const imageRef = useRef<HTMLImageElement>(null);
   const [imageFile, setImageFile] = useState<File>();
   const dispatch = useDispatch();
-  const { userNickName, userProfile, updateSucceed } = useSelector((state: RootState) => state.user);
+  const { userNickName, userProfile } = useSelector((state: RootState) => state.user);
   const [userImg, setUserImg] = useState<string>(userProfile);
   const [newName, setNewName] = useState<string>(userNickName);
 
@@ -53,26 +53,6 @@ const UserInfoModal = () => {
     closeUserInfoModal();
   };
 
-  useEffect(() => {
-    const updateSucceeded = () => {
-      closeUserInfoModal();
-      dispatch({ type: SET_UPDATED_INIT });
-    };
-
-    const updateFailed = () => {
-      // alert("회원정보 수정에 실패했습니다.");
-    };
-
-    if (updateSucceed === null) return;
-
-    if (updateSucceed) {
-      updateSucceeded();
-      return;
-    }
-
-    updateFailed();
-  }, [userNickName]);
-  
   const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setNewName(event.target.value);
   };

--- a/frontend/src/components/ToastMessage/Error.tsx
+++ b/frontend/src/components/ToastMessage/Error.tsx
@@ -6,14 +6,27 @@ import { FcHighPriority } from "react-icons/fc";
 import { useDispatch } from "react-redux";
 import { CLEAR_TOAST } from "@src/reducer/ToastReducer";
 import shortid from "shortid";
+import { useEffect } from "react";
 
 const Error = ({ text }: { text: string }) => {
   const dispatch = useDispatch();
   const key = shortid.generate();
+  const toastEl = document.getElementById("toast-message") as HTMLElement;
+
+  const setDisplayNone = () => {
+    toastEl.style.display = "none";
+  };
 
   const onClickCloseBtn = () => {
     dispatch({ type: CLEAR_TOAST });
+    setDisplayNone();
   };
+
+  useEffect(() => {
+    setTimeout(() => {
+      setDisplayNone();
+    }, 3000);
+  });
 
   return (
     <Toast>

--- a/frontend/src/components/ToastMessage/Succeed.tsx
+++ b/frontend/src/components/ToastMessage/Succeed.tsx
@@ -6,14 +6,27 @@ import { FcOk } from "react-icons/fc";
 import { useDispatch } from "react-redux";
 import { CLEAR_TOAST } from "@src/reducer/ToastReducer";
 import shortid from "shortid";
+import { useEffect } from "react";
 
 const Succeed = ({ text }: { text: string }) => {
   const dispatch = useDispatch();
   const key = shortid.generate();
+  const toastEl = document.getElementById("toast-message") as HTMLElement;
+
+  const setDisplayNone = () => {
+    toastEl.style.display = "none";
+  };
 
   const onClickCloseBtn = () => {
     dispatch({ type: CLEAR_TOAST });
+    setDisplayNone();
   };
+
+  useEffect(() => {
+    setTimeout(() => {
+      setDisplayNone();
+    }, 5000);
+  });
 
   return (
     <Toast>

--- a/frontend/src/components/ToastMessage/index.tsx
+++ b/frontend/src/components/ToastMessage/index.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from "react";
 
 const toastEl = document.getElementById("toast-message");
 if (toastEl) {
-  toastEl.style.display = "flex";
+  toastEl.style.display = "none";
   toastEl.style.justifyContent = "center";
   toastEl.style.alignItems = " flex-end";
   toastEl.style.width = "100%";
@@ -21,6 +21,7 @@ interface ToastProps {
 const Toast = ({ children }: ToastProps) => {
   if (!toastEl) return null;
 
+  toastEl.style.display = "flex";
   return ReactDOM.createPortal(children, toastEl);
 };
 

--- a/frontend/src/pages/Main/index.tsx
+++ b/frontend/src/pages/Main/index.tsx
@@ -21,7 +21,7 @@ const Main = () => {
   const dispatch = useDispatch();
   const { groups, groupListLoaded }: any = useSelector((state: RootState) => state.groups);
   const { spinnerActivate }: any = useSelector((state: RootState) => state.spinner);
-  const { userNickName, userInfoError, userLoggedOut } = useSelector((state: RootState) => state.user);
+  const { userInfoError, userLoggedOut, userInfoSucceed } = useSelector((state: RootState) => state.user);
   const history = useHistory();
 
   useEffect(() => {
@@ -41,10 +41,10 @@ const Main = () => {
   }, []);
 
   useEffect(() => {
-    if (userNickName) {
+    if (userInfoSucceed) {
       dispatch(getGroupListAction());
     }
-  }, [userNickName]);
+  }, [userInfoSucceed]);
 
   useEffect(() => {
     if (userLoggedOut | userInfoError) {
@@ -52,7 +52,7 @@ const Main = () => {
     }
   }, [userLoggedOut, userInfoError]);
 
-  if (!userNickName || !groupListLoaded) {
+  if (!userInfoSucceed || !groupListLoaded) {
     return <Spinner />;
   }
   return (


### PR DESCRIPTION
## 작업 내용
- 토스트 메세지가 렌더 트리상에 그려지지 않도록 `display`를 none 처리 했습니다.
- 회원 정보 변경 직후, 다시 회원 정보 수정 모달을 열려고 하면 안열리는 현상을 수정했습니다. `UserInfoModal`에서 사용되는 예전 코드 상에서, `useEffect` 안에서 모달을 곧바로 닫아버렸기 때문입니다.
- 회원 정보 변경 후, 잠깐 동안 스피너가 보이는 현상을 수정했습니다. `userNickname`이 잠깐 동안 없어지기 때문에 발생했던 현상으로, `userInfoSucceed`에 값에 따라 스피너가 보이도록 변경했습니다.

## 고민한 부분


## 리뷰 포인트


## 관련된 이슈 넘버
