### PR TITLE
지도 우클릭으로 생기는 게시물 생성 모달, 네이버맵의 InfoWindow 객체로 관리

### DIFF
--- a/frontend/src/components/Map/Modal/index.tsx
+++ b/frontend/src/components/Map/Modal/index.tsx
@@ -1,22 +1,11 @@
-import { useDispatch } from "react-redux";
 import COLOR from "@styles/Color";
 import styled from "styled-components";
 import { flexRowCenterAlign } from "@src/styles/StyledComponents";
-import { SET_RIGHT_CLICK_MODAL } from "@src/reducer/MapReducer";
 
 const MapLayerPostModal = (e: any) => {
-  const dispatch = useDispatch();
-
-  const modalOpen = (x: number, y: number) => {
-    dispatch({ type: SET_RIGHT_CLICK_MODAL, payload: { isRightClickModalOpened: false } });
-    dispatch({ type: "SET_ADDRESS", payload: "" });
-    dispatch({ type: "SET_POSITION", payload: { x, y } });
-    dispatch({ type: "OPEN_MODAL", payload: "UploadAddressModal" });
-  };
-
   return (
     <MapLayerModalContainer x={e.rightPosition.x} y={e.rightPosition.y}>
-      <MapLayerModal onClick={() => modalOpen(e.latLng.x, e.latLng.y)}>
+      <MapLayerModal onClick={() => e.modalOpen(e.latLng.x, e.latLng.y)}>
         <Content>
           <div>포스트 추가</div>
         </Content>
@@ -29,21 +18,23 @@ const MapLayerPostModal = (e: any) => {
 };
 
 const MapLayerModalContainer = styled.div<{ x: number; y: number }>`
-  position: absolute;
+  position: relative;
   z-index: 10;
-  left: ${(props) => `${props.x}px`};
-  top: ${(props) => `${props.y + 10}px`};
+  width: 100%;
+  height: 100%;
 `;
 
 const MapLayerModal = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
   background-color: ${COLOR.WHITE};
   padding: 0.5rem;
   border-radius: 1rem;
   border: solid 0.4rem ${COLOR.THEME1.SECONDARY};
   text-align: center;
   box-shadow: 0 2px 3px 0 ${COLOR.SHADOW_BLACK};
-  width: 5vw;
-  height: 3vh;
   ${flexRowCenterAlign};
   &:hover {
     cursor: pointer;

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -6,11 +6,10 @@ import { useSelector, useDispatch } from "react-redux";
 import { RootState } from "@src/reducer";
 import Marker from "@components/Map/Markers";
 import MapLayerPostModal from "./Modal";
-import dummyPosts from "./dummyPosts";
 import SetClustering from "@components/Map/SetClustering";
 import ReactDOM from "react-dom";
 import PostListModal from "@components/Modal/PostListModal";
-import { SET_RIGHT_CLICK_MODAL, SET_INFO_WINDOW, SET_INFO_WINDOW_OPENED } from "@src/reducer/MapReducer";
+import { SET_RIGHT_CLICK_MODAL, SET_CLUSTERING_WINDOW, SET_CLUSTERING_WINDOW_OPENED } from "@src/reducer/MapReducer";
 
 declare const MarkerClustering: any;
 declare global {
@@ -98,8 +97,8 @@ const setMap = (
     type: string;
     payload:
       | { isRightClickModalOpened: boolean }
-      | { infoWindow: naver.maps.InfoWindow }
-      | { isInfoWindowOpened: boolean };
+      | { clusteringWindow: naver.maps.InfoWindow }
+      | { isClusteringWindowOpened: boolean };
   }>,
 ) => {
   const pos = new naver.maps.LatLng(INIT_X, INIT_Y);
@@ -111,14 +110,14 @@ const setMap = (
   });
 
   setNaverMap(map);
-  const newInfoWindow = new naver.maps.InfoWindow({
+  const newClusteringWindow = new naver.maps.InfoWindow({
     content: "",
     maxWidth: 200,
     borderColor: COLOR.GRAY,
     borderWidth: 2,
     disableAnchor: true,
   });
-  dispatch({ type: SET_INFO_WINDOW, payload: { infoWindow: newInfoWindow } });
+  dispatch({ type: SET_CLUSTERING_WINDOW, payload: { clusteringWindow: newClusteringWindow } });
 
   naver.maps.Event.addListener(map, "rightclick", (e: PointerEvent) => {
     setClickInfo(e);
@@ -128,13 +127,13 @@ const setMap = (
   });
   naver.maps.Event.addListener(map, "zoom_changed", (e: Number) => {
     dispatch({ type: SET_RIGHT_CLICK_MODAL, payload: { isRightClickModalOpened: false } });
-    newInfoWindow.close();
-    dispatch({ type: SET_INFO_WINDOW_OPENED, payload: { isInfoWindowOpened: false } });
+    newClusteringWindow.close();
+    dispatch({ type: SET_CLUSTERING_WINDOW_OPENED, payload: { isClusteringWindowOpened: false } });
   });
   naver.maps.Event.addListener(map, "mousedown", (e: PointerEvent) => {
     dispatch({ type: SET_RIGHT_CLICK_MODAL, payload: { isRightClickModalOpened: false } });
-    newInfoWindow.close();
-    dispatch({ type: SET_INFO_WINDOW_OPENED, payload: { isInfoWindowOpened: false } });
+    newClusteringWindow.close();
+    dispatch({ type: SET_CLUSTERING_WINDOW_OPENED, payload: { isClusteringWindowOpened: false } });
   });
 };
 
@@ -142,8 +141,8 @@ const Map = () => {
   const dispatch = useDispatch();
   const {
     isRightClickModalOpened,
-    infoWindow,
-  }: { isRightClickModalOpened: boolean; infoWindow: naver.maps.InfoWindow | null } = useSelector(
+    clusteringWindow,
+  }: { isRightClickModalOpened: boolean; clusteringWindow: naver.maps.InfoWindow | null } = useSelector(
     (state: RootState) => state.map,
   );
   const [rightPosition, setRightPosition] = useState<Point>({ x: 0, y: 0 });
@@ -171,8 +170,8 @@ const Map = () => {
 
     const setMarker = () => {
       const handleClickMarker = (clickedPostID: number) => {
-        if (infoWindow) {
-          infoWindow.close();
+        if (clusteringWindow) {
+          clusteringWindow.close();
         }
         dispatch({ type: SET_RIGHT_CLICK_MODAL, payload: { isRightClickModalOpened: false } });
         dispatch({ type: "SELECT_POST_REQUEST", postId: clickedPostID });
@@ -191,11 +190,11 @@ const Map = () => {
           return { postId: member.postId, postTitle: member.title };
         });
 
-        if (!infoWindow) return;
-        infoWindow.setContent(['<div id="clustredMarkerList" style="width:20rem;height:10rem;">'].join(""));
+        if (!clusteringWindow) return;
+        clusteringWindow.setContent(['<div id="clustredMarkerList" style="width:20rem;height:10rem;">'].join(""));
         if (!naverMap) return;
-        infoWindow.open(naverMap, LatLng);
-        dispatch({ type: SET_INFO_WINDOW_OPENED, payload: { isInfoWindowOpened: true } });
+        clusteringWindow.open(naverMap, LatLng);
+        dispatch({ type: SET_CLUSTERING_WINDOW_OPENED, payload: { isClusteringWindowOpened: true } });
 
         ReactDOM.render(
           <React.StrictMode>

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -9,7 +9,12 @@ import MapLayerPostModal from "./Modal";
 import SetClustering from "@components/Map/SetClustering";
 import ReactDOM from "react-dom";
 import PostListModal from "@components/Modal/PostListModal";
-import { SET_RIGHT_CLICK_MODAL, SET_CLUSTERING_WINDOW, SET_CLUSTERING_WINDOW_OPENED } from "@src/reducer/MapReducer";
+import {
+  SET_CLUSTERING_WINDOW,
+  SET_CLUSTERING_WINDOW_OPENED,
+  SET_POST_CREATE_WINDOW,
+  SET_POST_CREATE_WINDOW_OPENED,
+} from "@src/reducer/MapReducer";
 
 declare const MarkerClustering: any;
 declare global {
@@ -44,12 +49,6 @@ interface PostType {
   postLatitude: number;
   postLongitude: number;
 }
-
-interface IDispatch {
-  type: string;
-  payload: any;
-}
-
 interface IPodo {
   content: string;
   size: naver.maps.Size;
@@ -76,29 +75,30 @@ interface IPostsList {
   postsList: PostType[];
 }
 
-interface ISelectedPost {
-  postId: number;
-  postTitle: string;
-  postContent: string;
-  postDate: string;
-  userNickname: string;
-  postImages: Array<{ file: string; key: string }>;
-}
+const convertWidth = (width: number) => {
+  if (width <= 768) return 4;
+  if (width <= 1100) return 6;
+  if (width <= 1440) return 8;
+  if (width <= 2000) return 10;
+  if (width <= 3000) return 12;
+  if (width <= 6000) return 24;
+  return 30;
+};
 
 const setMap = (
   INIT_X: number,
   INIT_Y: number,
   ZOOM_SIZE: number,
-  setRightPosition: Dispatch<SetStateAction<Point>>,
-  setLatLng: Dispatch<SetStateAction<naver.maps.LatLng | undefined>>,
-  setClickInfo: Dispatch<SetStateAction<PointerEvent>>,
   setNaverMap: Dispatch<SetStateAction<naver.maps.Map | undefined>>,
   dispatch: Dispatch<{
     type: string;
     payload:
-      | { isRightClickModalOpened: boolean }
       | { clusteringWindow: naver.maps.InfoWindow }
-      | { isClusteringWindowOpened: boolean };
+      | { isClusteringWindowOpened: boolean }
+      | { postCreateWindow: naver.maps.InfoWindow }
+      | { isPostCreateWindowOpened: boolean }
+      | string
+      | { x: number; y: number };
   }>,
 ) => {
   const pos = new naver.maps.LatLng(INIT_X, INIT_Y);
@@ -117,22 +117,55 @@ const setMap = (
     borderWidth: 2,
     disableAnchor: true,
   });
+
+  const newPostCreateWindow = new naver.maps.InfoWindow({
+    content: "",
+    maxWidth: 200,
+    disableAnchor: true,
+    borderColor: "transparent",
+    backgroundColor: "transparent",
+    pixelOffset: { x: 5 * convertWidth(window.innerWidth), y: 5 * convertWidth(window.innerWidth) },
+  });
+
   dispatch({ type: SET_CLUSTERING_WINDOW, payload: { clusteringWindow: newClusteringWindow } });
+  dispatch({ type: SET_POST_CREATE_WINDOW, payload: { postCreateWindow: newPostCreateWindow } });
 
   naver.maps.Event.addListener(map, "rightclick", (e: PointerEvent) => {
-    setClickInfo(e);
-    setLatLng(e.latlng);
-    setRightPosition({ x: e.pointerEvent.pageX, y: e.pointerEvent.pageY });
-    dispatch({ type: SET_RIGHT_CLICK_MODAL, payload: { isRightClickModalOpened: true } });
+    newPostCreateWindow.setContent(
+      ['<div id="createPostWindow" style="border: none; width: 10rem; height: 4rem;">'].join(""),
+    );
+    newPostCreateWindow.open(map, e.latlng);
+
+    const modalOpen = (x: number, y: number) => {
+      dispatch({ type: SET_POST_CREATE_WINDOW_OPENED, payload: { isPostCreateWindowOpened: false } });
+      dispatch({ type: "SET_ADDRESS", payload: "" });
+      dispatch({ type: "SET_POSITION", payload: { x, y } });
+      dispatch({ type: "OPEN_MODAL", payload: "UploadAddressModal" });
+    };
+
+    ReactDOM.render(
+      <React.StrictMode>
+        <MapLayerPostModal
+          latLng={e.latlng}
+          clickInfo={e}
+          rightPosition={{ x: e.pointerEvent.pageX, y: e.pointerEvent.pageY }}
+          modalOpen={modalOpen}
+        />
+      </React.StrictMode>,
+      document.getElementById("createPostWindow"),
+    );
+
+    dispatch({ type: SET_POST_CREATE_WINDOW_OPENED, payload: { isPostCreateWindowOpened: true } });
   });
   naver.maps.Event.addListener(map, "zoom_changed", (e: Number) => {
-    dispatch({ type: SET_RIGHT_CLICK_MODAL, payload: { isRightClickModalOpened: false } });
+    dispatch({ type: SET_POST_CREATE_WINDOW_OPENED, payload: { isPostCreateWindowOpened: false } });
     newClusteringWindow.close();
     dispatch({ type: SET_CLUSTERING_WINDOW_OPENED, payload: { isClusteringWindowOpened: false } });
   });
   naver.maps.Event.addListener(map, "mousedown", (e: PointerEvent) => {
-    dispatch({ type: SET_RIGHT_CLICK_MODAL, payload: { isRightClickModalOpened: false } });
     newClusteringWindow.close();
+    newPostCreateWindow.close();
+    dispatch({ type: SET_POST_CREATE_WINDOW_OPENED, payload: { isPostCreateWindowOpened: false } });
     dispatch({ type: SET_CLUSTERING_WINDOW_OPENED, payload: { isClusteringWindowOpened: false } });
   });
 };
@@ -140,15 +173,13 @@ const setMap = (
 const Map = () => {
   const dispatch = useDispatch();
   const {
-    isRightClickModalOpened,
     clusteringWindow,
-  }: { isRightClickModalOpened: boolean; clusteringWindow: naver.maps.InfoWindow | null } = useSelector(
+    postCreateWindow,
+  }: { clusteringWindow: naver.maps.InfoWindow | null; postCreateWindow: naver.maps.InfoWindow | null } = useSelector(
     (state: RootState) => state.map,
   );
-  const [rightPosition, setRightPosition] = useState<Point>({ x: 0, y: 0 });
-  const [clickInfo, setClickInfo] = useState<any>();
+
   const [naverMap, setNaverMap] = useState<naver.maps.Map>();
-  const [latLng, setLatLng] = useState<naver.maps.LatLng>();
   const [currentMarkers, setCurrentMarkers] = useState<Array<naver.maps.Marker>>([]);
   const [currentClustering, setCurrentClustering] = useState<IMarkerClustering | undefined>(undefined);
   const { postsList }: IPostsList = useSelector((state: RootState) => state.groups);
@@ -160,7 +191,7 @@ const Map = () => {
       const INIT_X = 37.511337;
       const INIT_Y = 127.012084;
       const ZOOM_SIZE = 13;
-      setMap(INIT_X, INIT_Y, ZOOM_SIZE, setRightPosition, setLatLng, setClickInfo, setNaverMap, dispatch);
+      setMap(INIT_X, INIT_Y, ZOOM_SIZE, setNaverMap, dispatch);
     };
     initMap();
   }, []);
@@ -170,10 +201,10 @@ const Map = () => {
 
     const setMarker = () => {
       const handleClickMarker = (clickedPostID: number) => {
-        if (clusteringWindow) {
-          clusteringWindow.close();
-        }
-        dispatch({ type: SET_RIGHT_CLICK_MODAL, payload: { isRightClickModalOpened: false } });
+        if (clusteringWindow) clusteringWindow.close();
+        if (postCreateWindow) postCreateWindow.close();
+
+        dispatch({ type: SET_POST_CREATE_WINDOW_OPENED, payload: { isPostCreateWindowOpened: false } });
         dispatch({ type: "SELECT_POST_REQUEST", postId: clickedPostID });
       };
 
@@ -185,7 +216,7 @@ const Map = () => {
       });
 
       const handleClickClustering = (members: IClustredMember[], LatLng: naver.maps.LatLng) => {
-        dispatch({ type: SET_RIGHT_CLICK_MODAL, payload: { isRightClickModalOpened: false } });
+        dispatch({ type: SET_POST_CREATE_WINDOW_OPENED, payload: { isPostCreateWindowOpened: false } });
         const clusteredMarker = members.map((member) => {
           return { postId: member.postId, postTitle: member.title };
         });
@@ -248,9 +279,6 @@ const Map = () => {
   return (
     <React.Fragment>
       <Maps id="map" />
-      {isRightClickModalOpened && (
-        <MapLayerPostModal latLng={latLng} clickInfo={clickInfo} rightPosition={rightPosition} />
-      )}
       <FloatActionBtn onClick={modalOpen}>+</FloatActionBtn>
     </React.Fragment>
   );

--- a/frontend/src/pages/Main/index.tsx
+++ b/frontend/src/pages/Main/index.tsx
@@ -12,7 +12,7 @@ import { RootState } from "@src/reducer";
 import { useHistory } from "react-router-dom";
 import { getGroupListAction } from "@src/reducer/GroupReducer";
 import ToastManager from "@src/components/ToastMessage/ToastManager";
-import { SET_RIGHT_CLICK_MODAL } from "@src/reducer/MapReducer";
+import { CLOSE_POST_CREATE_WINDOW, SET_POST_CREATE_WINDOW_OPENED } from "@src/reducer/MapReducer";
 import { SET_PROFILE_WRAPPER_MODAL_OPENED, SET_ALBUM_SETTING_WRAPPER_MODAL_IDX } from "@src/reducer/Modal";
 import Spinner from "@components/Spinner";
 import { CLOSE_CLUSTERING_WINDOW } from "@src/reducer/MapReducer";
@@ -28,11 +28,13 @@ const Main = () => {
   useEffect(() => {
     document.addEventListener("click", (event) => {
       const { target, clientX, clientY } = event;
-      dispatch({ type: GroupModalAction.SET_CLICKED_TARGET, payload: { target, clientX, clientY } });
-      dispatch({ type: SET_RIGHT_CLICK_MODAL, payload: { isRightClickModalOpened: false } });
-
       const isClusteringClicked = (target as HTMLElement).getAttribute("src")?.match(/\/icons\/podo-(three|many).png/);
+      const isPostCreateClicked = (target as HTMLElement).closest("#createPostWindow");
+
+      dispatch({ type: GroupModalAction.SET_CLICKED_TARGET, payload: { target, clientX, clientY } });
+      dispatch({ type: SET_POST_CREATE_WINDOW_OPENED, payload: { isPostCreateWindowOpened: false } });
       !isClusteringClicked && dispatch({ type: CLOSE_CLUSTERING_WINDOW });
+      !isPostCreateClicked && dispatch({ type: CLOSE_POST_CREATE_WINDOW });
     });
 
     document.addEventListener("contextmenu", () => {

--- a/frontend/src/pages/Main/index.tsx
+++ b/frontend/src/pages/Main/index.tsx
@@ -15,6 +15,7 @@ import ToastManager from "@src/components/ToastMessage/ToastManager";
 import { SET_RIGHT_CLICK_MODAL } from "@src/reducer/MapReducer";
 import { SET_PROFILE_WRAPPER_MODAL_OPENED, SET_ALBUM_SETTING_WRAPPER_MODAL_IDX } from "@src/reducer/Modal";
 import Spinner from "@components/Spinner";
+import { CLOSE_CLUSTERING_WINDOW } from "@src/reducer/MapReducer";
 
 const Main = () => {
   const [isToggle, setIsToggle] = useState<boolean>(true);
@@ -31,7 +32,7 @@ const Main = () => {
       dispatch({ type: SET_RIGHT_CLICK_MODAL, payload: { isRightClickModalOpened: false } });
 
       const isClusteringClicked = (target as HTMLElement).getAttribute("src")?.match(/\/icons\/podo-(three|many).png/);
-      !isClusteringClicked && dispatch({ type: "CLOSE_INFO_WINDOW" });
+      !isClusteringClicked && dispatch({ type: CLOSE_CLUSTERING_WINDOW });
     });
 
     document.addEventListener("contextmenu", () => {

--- a/frontend/src/reducer/MapReducer.ts
+++ b/frontend/src/reducer/MapReducer.ts
@@ -1,28 +1,26 @@
 interface IInitState {
-  isRightClickModalOpened: boolean;
   clusteringWindow: naver.maps.InfoWindow | null;
   isClusteringWindowOpened: boolean;
+  postCreateWindow: naver.maps.InfoWindow | null;
+  isPostCreateWindowOpened: boolean;
 }
 
 const initState: IInitState = {
-  isRightClickModalOpened: false,
   clusteringWindow: null,
   isClusteringWindowOpened: false,
+  postCreateWindow: null,
+  isPostCreateWindowOpened: false,
 };
 
-export const SET_RIGHT_CLICK_MODAL = "SET_RIGHT_CLICK_MODAL";
 export const SET_CLUSTERING_WINDOW = "SET_CLUSTERING_WINDOW";
-export const CLOSE_CLUSTERING_WINDOW = "CLOSE_CLUSTERING_WINDOW";
 export const SET_CLUSTERING_WINDOW_OPENED = "SET_CLUSTERING_WINDOW_OPENED";
+export const CLOSE_CLUSTERING_WINDOW = "CLOSE_CLUSTERING_WINDOW";
+export const SET_POST_CREATE_WINDOW = "SET_POST_CREATE_WINDOW";
+export const SET_POST_CREATE_WINDOW_OPENED = "SET_POST_CREATE_WINDOW_OPENED";
+export const CLOSE_POST_CREATE_WINDOW = "CLOSE_POST_CREATE_WINDOW";
 
 const mapReducer = (state = initState, action: any) => {
   switch (action.type) {
-    case SET_RIGHT_CLICK_MODAL: {
-      return {
-        ...state,
-        isRightClickModalOpened: action.payload.isRightClickModalOpened,
-      };
-    }
     case SET_CLUSTERING_WINDOW: {
       return {
         ...state,
@@ -37,7 +35,24 @@ const mapReducer = (state = initState, action: any) => {
       };
     }
     case CLOSE_CLUSTERING_WINDOW: {
-      state.clusteringWindow && state.isClusteringWindowOpened && state.clusteringWindow.close();
+      state.clusteringWindow && state.clusteringWindow.close();
+      return state;
+    }
+    case SET_POST_CREATE_WINDOW: {
+      return {
+        ...state,
+        postCreateWindow: action.payload.postCreateWindow,
+      };
+    }
+
+    case SET_POST_CREATE_WINDOW_OPENED: {
+      return {
+        ...state,
+        isPostCreateWindowOpened: action.payload.isPostCreateWindowOpened,
+      };
+    }
+    case CLOSE_POST_CREATE_WINDOW: {
+      state.postCreateWindow && state.postCreateWindow.close();
       return state;
     }
 

--- a/frontend/src/reducer/MapReducer.ts
+++ b/frontend/src/reducer/MapReducer.ts
@@ -1,19 +1,19 @@
 interface IInitState {
   isRightClickModalOpened: boolean;
-  infoWindow: naver.maps.InfoWindow | null;
-  isInfoWindowOpened: boolean;
+  clusteringWindow: naver.maps.InfoWindow | null;
+  isClusteringWindowOpened: boolean;
 }
 
 const initState: IInitState = {
   isRightClickModalOpened: false,
-  infoWindow: null,
-  isInfoWindowOpened: false,
+  clusteringWindow: null,
+  isClusteringWindowOpened: false,
 };
 
 export const SET_RIGHT_CLICK_MODAL = "SET_RIGHT_CLICK_MODAL";
-export const SET_INFO_WINDOW = "SET_INFO_WINDOW";
-export const CLOSE_INFO_WINDOW = "CLOSE_INFO_WINDOW";
-export const SET_INFO_WINDOW_OPENED = "SET_INFO_WINDOW_OPENED";
+export const SET_CLUSTERING_WINDOW = "SET_CLUSTERING_WINDOW";
+export const CLOSE_CLUSTERING_WINDOW = "CLOSE_CLUSTERING_WINDOW";
+export const SET_CLUSTERING_WINDOW_OPENED = "SET_CLUSTERING_WINDOW_OPENED";
 
 const mapReducer = (state = initState, action: any) => {
   switch (action.type) {
@@ -23,21 +23,21 @@ const mapReducer = (state = initState, action: any) => {
         isRightClickModalOpened: action.payload.isRightClickModalOpened,
       };
     }
-    case SET_INFO_WINDOW: {
+    case SET_CLUSTERING_WINDOW: {
       return {
         ...state,
-        infoWindow: action.payload.infoWindow,
+        clusteringWindow: action.payload.clusteringWindow,
       };
     }
 
-    case SET_INFO_WINDOW_OPENED: {
+    case SET_CLUSTERING_WINDOW_OPENED: {
       return {
         ...state,
-        isInfoWindowOpened: action.payload.isInfoWindowOpened,
+        isClusteringWindowOpened: action.payload.isClusteringWindowOpened,
       };
     }
-    case CLOSE_INFO_WINDOW: {
-      state.infoWindow && state.isInfoWindowOpened && state.infoWindow.close();
+    case CLOSE_CLUSTERING_WINDOW: {
+      state.clusteringWindow && state.isClusteringWindowOpened && state.clusteringWindow.close();
       return state;
     }
 


### PR DESCRIPTION
## 작업 내용
### 게시물 생성 모달 InfoWindow객체로 관리하도록 수정

![video3](https://user-images.githubusercontent.com/50266862/143233079-e93ea5e2-b6dc-4ee4-af08-7646187d64dd.gif)

- 지도 가장자리에서 우클릭 할 경우, 화면 바깥으로 벗어나는 현상이 있었습니다.
- InfoWindow에는 `disableAutoPan` 속성 값에 따라서 네이버 지도 API가 알아서 해당 모달전체가 보여지게끔 지도를 이동시켜주는 기능이 있습니다.
- InfoWindow를 사용하기 위해, 구조도 조금 변경되었습니다.

## 고민한 부분
- InfoWindow는 클릭 이벤트가 일어난 위치를 정가운데로 말풍선을 띄우는데, 이걸 우리 프로젝트에 맞게 어떻게 우하단으로 이동시킬 지 고민함.

## 리뷰 포인트


## 관련된 이슈 넘버
