### PR TITLE
해시태그 조회 API 및 jwt 개선

### DIFF
--- a/backend/src/album/album.module.ts
+++ b/backend/src/album/album.module.ts
@@ -6,9 +6,11 @@ import { AlbumService } from "./service/album.service";
 import { AlbumRepository } from "./album.repository";
 import { GroupRepository } from "src/group/group.repository";
 import { PostRepository } from "src/post/post.repository";
+import { AuthModule } from "src/auth/auth.module";
 
 @Module({
   imports: [
+    AuthModule,
     TypeOrmModule.forFeature([AlbumRepository, GroupRepository, PostRepository]),
     JwtModule.register({
       secret: process.env.JWT_SECRET,

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { UserModule } from "src/user/user.module";
 import { AuthController } from "./controller/auth.controller";
 import { AuthService } from "./service/auth.service";
@@ -8,12 +8,13 @@ import { JwtStrategy } from "./strategy/jwt.strategy";
 
 @Module({
   imports: [
-    UserModule,
+    forwardRef(() => UserModule),
     JwtModule.register({
       secret: process.env.JWT_SECRET,
     }),
   ],
   controllers: [AuthController],
   providers: [AuthService, NaverStrategy, JwtStrategy],
+  exports: [AuthService],
 })
 export class AuthModule {}

--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -27,8 +27,8 @@ export class AuthController {
   async naverAuthRedirect(@Req() { user }: CustomRequest, @Res() res: Response) {
     const { accessToken, refreshToken } = user;
 
-    res.cookie("accessToken", accessToken);
-    res.cookie("refreshToken", refreshToken);
+    res.cookie("accessToken", accessToken, { httpOnly: true });
+    res.cookie("refreshToken", refreshToken, { httpOnly: true });
 
     const redirectUrl = process.env.NODE_ENV === "dev" ? process.env.DEV_REDIRECT_URL : process.env.PROD_REDIRECT_URL;
 

--- a/backend/src/auth/controller/auth.controller.ts
+++ b/backend/src/auth/controller/auth.controller.ts
@@ -7,6 +7,7 @@ import { CustomRequest } from "src/custom/myRequest/customRequest";
 import { UserService } from "src/user/service/user.service";
 import { AuthService } from "../service/auth.service";
 import { NaverFilter } from "src/filter/naver.filter";
+import { JwtRefreshTokenAuthGuard } from "../guard/jwt-refreshToken-auth-guard";
 
 @ApiTags("auth API")
 @ApiBearerAuth()
@@ -26,11 +27,8 @@ export class AuthController {
   async naverAuthRedirect(@Req() { user }: CustomRequest, @Res() res: Response) {
     const { accessToken, refreshToken } = user;
 
-    const accessTokenTokenExpireTime = 1000 * 60 * 60;
-    const refreshTokenExpireTime = accessTokenTokenExpireTime * 24 * 7;
-
-    res.cookie("accessToken", accessToken, { maxAge: accessTokenTokenExpireTime });
-    res.cookie("refreshToken", refreshToken, { maxAge: refreshTokenExpireTime });
+    res.cookie("accessToken", accessToken);
+    res.cookie("refreshToken", refreshToken);
 
     const redirectUrl = process.env.NODE_ENV === "dev" ? process.env.DEV_REDIRECT_URL : process.env.PROD_REDIRECT_URL;
 
@@ -49,26 +47,9 @@ export class AuthController {
     res.end();
   }
 
-  @Get("/demo/login")
-  async DemoLogin(@Res() res: Response) {
-    const userId = 9;
-    const userEmail = "test@test.com";
-
-    const accessTokenExpireTime = "1h";
-    const refreshTokenExpireTime = "7d";
-    const accessToken = this.authService.createToken(userId, userEmail, accessTokenExpireTime);
-    const refreshToken = this.authService.createToken(userId, userEmail, refreshTokenExpireTime);
-
-    await this.userService.updateToken(userId, refreshToken);
-
-    const cookieAccessTokenTokenExpireTime = 1000 * 60 * 60;
-    const cookieRefreshTokenExpireTime = cookieAccessTokenTokenExpireTime * 24 * 7;
-
-    res.cookie("accessToken", accessToken, { maxAge: cookieAccessTokenTokenExpireTime });
-    res.cookie("refreshToken", refreshToken, { maxAge: cookieRefreshTokenExpireTime });
-
-    const redirectUrl = process.env.NODE_ENV === "dev" ? process.env.DEV_REDIRECT_URL : process.env.PROD_REDIRECT_URL;
-
-    res.redirect(redirectUrl);
+  @Get("refresh-token")
+  @UseGuards(JwtRefreshTokenAuthGuard)
+  async refreshToken() {
+    return;
   }
 }

--- a/backend/src/auth/guard/jwt-auth-guard.ts
+++ b/backend/src/auth/guard/jwt-auth-guard.ts
@@ -1,53 +1,21 @@
-import { ExecutionContext, Injectable, UnauthorizedException } from "@nestjs/common";
+import { ExecutionContext, Injectable } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
-import { JwtService } from "@nestjs/jwt";
+import { AuthService } from "../service/auth.service";
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard("jwt") {
-  constructor(private jwtService: JwtService) {
+  constructor(private authService: AuthService) {
     super();
   }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
-    const response = context.switchToHttp().getResponse();
 
-    const { accessToken, refreshToken } = request.cookies;
+    const { accessToken } = request.cookies;
 
-    const validationAccessToken = await this.validateToken(accessToken);
-    if (validationAccessToken) {
-      request.user = validationAccessToken;
-      return true;
-    }
+    const validationAccessToken = await this.authService.validateToken(accessToken, "AccessToken");
 
-    const validationRefreshToken = await this.validateToken(refreshToken);
-    if (!validationRefreshToken) throw new UnauthorizedException("Expired RefreshToken");
-
-    const { userId, userEmail } = validationRefreshToken;
-    const accessTokenExpireTime = "1h";
-    const newAccessToken = this.createToken(userId, userEmail, accessTokenExpireTime);
-    response.cookie("accessToken", newAccessToken);
-    request.user = validationRefreshToken;
-
+    request.user = validationAccessToken;
     return true;
-  }
-
-  async validateToken(token: string): Promise<{ userId: number; userEmail: string }> {
-    try {
-      const { userId, userEmail } = await this.jwtService.verify(token);
-      return { userId, userEmail };
-    } catch (e) {
-      return undefined;
-    }
-  }
-
-  createToken(userId: number, userEmail: string, expire: string): string {
-    const payload = {
-      userId: userId,
-      userEmail: userEmail,
-      userToken: "loginToken",
-    };
-
-    return this.jwtService.sign(payload, { expiresIn: expire });
   }
 }

--- a/backend/src/auth/guard/jwt-refreshToken-auth-guard.ts
+++ b/backend/src/auth/guard/jwt-refreshToken-auth-guard.ts
@@ -1,0 +1,30 @@
+import { ExecutionContext, Injectable, UnauthorizedException } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import { AuthService } from "../service/auth.service";
+
+@Injectable()
+export class JwtRefreshTokenAuthGuard extends AuthGuard("jwt") {
+  constructor(private authService: AuthService) {
+    super();
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const response = context.switchToHttp().getResponse();
+
+    const { refreshToken } = request.cookies;
+
+    const validationRefreshToken = await this.authService.validateToken(refreshToken, "RefreshToken");
+    if (validationRefreshToken.refreshToken !== refreshToken) {
+      throw new UnauthorizedException("Unauthorized RefreshToken");
+    }
+
+    const { userId, userEmail } = validationRefreshToken;
+    const accessTokenExpireTime = "30m";
+    const newAccessToken = this.authService.createToken(userId, userEmail, accessTokenExpireTime);
+    response.cookie("accessToken", newAccessToken);
+    request.user = validationRefreshToken;
+
+    return true;
+  }
+}

--- a/backend/src/auth/guard/jwt-refreshToken-auth-guard.ts
+++ b/backend/src/auth/guard/jwt-refreshToken-auth-guard.ts
@@ -21,8 +21,8 @@ export class JwtRefreshTokenAuthGuard extends AuthGuard("jwt") {
 
     const { userId, userEmail } = validationRefreshToken;
     const accessTokenExpireTime = "30m";
-    const newAccessToken = this.authService.createToken(userId, userEmail, accessTokenExpireTime);
-    response.cookie("accessToken", newAccessToken);
+    const newAccessToken = this.authService.createToken(userId, userEmail, accessTokenExpireTime, "accessToken");
+    response.cookie("accessToken", newAccessToken, { httpOnly: true });
     request.user = validationRefreshToken;
 
     return true;

--- a/backend/src/auth/service/auth.service.ts
+++ b/backend/src/auth/service/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { UserInfo } from "src/dto/user/userInfo.dto";
 import { JwtService } from "@nestjs/jwt";
 import { UserService } from "src/user/service/user.service";
@@ -12,6 +12,16 @@ export class AuthService {
     const user = await this.userService.registeredUser(registerUserDto);
 
     return user;
+  }
+
+  async validateToken(token: string, message: string): Promise<User> {
+    try {
+      const { userId } = await this.jwtService.verify(token);
+
+      return await this.userService.findById(userId);
+    } catch (e) {
+      throw new UnauthorizedException(`Expired AccessToken ${message}`);
+    }
   }
 
   createToken(userId: number, userEmail: string, expire: string): string {

--- a/backend/src/auth/service/auth.service.ts
+++ b/backend/src/auth/service/auth.service.ts
@@ -24,11 +24,11 @@ export class AuthService {
     }
   }
 
-  createToken(userId: number, userEmail: string, expire: string): string {
+  createToken(userId: number, userEmail: string, expire: string, token: string): string {
     const payload = {
       userId: userId,
       userEmail: userEmail,
-      userToken: "loginToken",
+      Token: token,
     };
 
     return this.jwtService.sign(payload, { expiresIn: expire });

--- a/backend/src/auth/strategy/naver.strategy.ts
+++ b/backend/src/auth/strategy/naver.strategy.ts
@@ -31,8 +31,8 @@ export class NaverStrategy extends PassportStrategy(Strategy, "naver") {
 
     const { userId, userEmail } = user;
 
-    const accessTokenExpireTime = "1h";
-    const refreshTokenExpireTime = "7d";
+    const accessTokenExpireTime = "30m";
+    const refreshTokenExpireTime = "14d";
     const accessToken = this.authService.createToken(userId, userEmail, accessTokenExpireTime);
     const refreshToken = this.authService.createToken(userId, userEmail, refreshTokenExpireTime);
 

--- a/backend/src/auth/strategy/naver.strategy.ts
+++ b/backend/src/auth/strategy/naver.strategy.ts
@@ -33,8 +33,8 @@ export class NaverStrategy extends PassportStrategy(Strategy, "naver") {
 
     const accessTokenExpireTime = "30m";
     const refreshTokenExpireTime = "14d";
-    const accessToken = this.authService.createToken(userId, userEmail, accessTokenExpireTime);
-    const refreshToken = this.authService.createToken(userId, userEmail, refreshTokenExpireTime);
+    const accessToken = this.authService.createToken(userId, userEmail, accessTokenExpireTime, "accessToken");
+    const refreshToken = this.authService.createToken(userId, userEmail, refreshTokenExpireTime, "refreshToken");
 
     await this.userService.updateToken(userId, refreshToken);
 

--- a/backend/src/configs/s3.config.ts
+++ b/backend/src/configs/s3.config.ts
@@ -24,11 +24,10 @@ export const multerOption = {
           const url = `${process.env.NCP_OBJECT_STORAGE_PATH}/${groupId}/${encodeURI(Date.now().toString())} - ${
             file.originalname
           }`;
-
           callback(null, url);
         },
         transform: async function (request, file, callback) {
-          callback(null, sharp().webp({ quality: 50 })); // 추후 리사이징 필요시 수정
+          callback(null, sharp().webp({ quality: 80 }));
         },
       },
     ],

--- a/backend/src/group/group.module.ts
+++ b/backend/src/group/group.module.ts
@@ -1,12 +1,14 @@
 import { Module } from "@nestjs/common";
 import { JwtModule } from "@nestjs/jwt";
 import { TypeOrmModule } from "@nestjs/typeorm";
+import { AuthModule } from "src/auth/auth.module";
 import { GroupController } from "./controller/group.controller";
 import { GroupRepository } from "./group.repository";
 import { GroupService } from "./service/group.service";
 
 @Module({
   imports: [
+    AuthModule,
     TypeOrmModule.forFeature([GroupRepository]),
     JwtModule.register({
       secret: process.env.JWT_SECRET,

--- a/backend/src/group/group.repository.ts
+++ b/backend/src/group/group.repository.ts
@@ -47,11 +47,12 @@ export class GroupRepository extends Repository<Group> {
       .getOne();
   }
 
-  async getHashTagsQuery(groupId: number): Promise<Group> {
+  async getHashTagsQuery(groupId: number): Promise<Group | undefined> {
     return await this.createQueryBuilder("group")
       .leftJoin("group.hashtags", "hashtag")
+      .leftJoin("hashtag.posts", "post")
       .select(["group.groupId", "hashtag.hashtagId", "hashtag.hashtagContent"])
-      .where("group.groupId=:id", { id: groupId })
+      .where("group.groupId=:id AND post.postId is not null", { id: groupId })
       .getOne();
   }
 }

--- a/backend/src/group/service/group.service.ts
+++ b/backend/src/group/service/group.service.ts
@@ -208,8 +208,8 @@ export class GroupService {
   }
 
   async getHashTags(groupId: number): Promise<GetHashTagsResponseDto> {
-    const { hashtags } = await this.groupRepository.getHashTagsQuery(groupId);
+    const result = await this.groupRepository.getHashTagsQuery(groupId);
 
-    return { hashtags };
+    return result === undefined ? { hashtags: [] } : { hashtags: result.hashtags };
   }
 }

--- a/backend/src/post/post.module.ts
+++ b/backend/src/post/post.module.ts
@@ -10,12 +10,14 @@ import { ImageModule } from "src/image/image.module";
 import { AlbumModule } from "src/album/album.module";
 import { HashtagModule } from "src/hashtag/hashtag.module";
 import { HashTagRepository } from "src/hashtag/hashtag.repository";
+import { AuthModule } from "src/auth/auth.module";
 
 @Module({
   imports: [
     ImageModule,
     AlbumModule,
     HashtagModule,
+    AuthModule,
     TypeOrmModule.forFeature([PostRepository, UserRepository, AlbumRepository, HashTagRepository]),
     JwtModule.register({
       secret: process.env.JWT_SECRET,

--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -80,4 +80,8 @@ export class UserService {
 
     return { groups: reArrangedGroups };
   }
+
+  async findById(userId: number): Promise<User> {
+    return await this.userRepository.findOne(userId);
+  }
 }

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,12 +1,14 @@
-import { Module } from "@nestjs/common";
+import { forwardRef, Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { UserController } from "./controller/user.controller";
 import { UserService } from "./service/user.service";
 import { UserRepository } from "./user.repository";
 import { JwtModule } from "@nestjs/jwt";
+import { AuthModule } from "src/auth/auth.module";
 
 @Module({
   imports: [
+    forwardRef(() => AuthModule),
     TypeOrmModule.forFeature([UserRepository]),
     JwtModule.register({
       secret: process.env.JWT_SECRET,


### PR DESCRIPTION
## 작업 내용
- 해시태그 조회 API
- jwt refresh Token 개선

## 고민한 부분
- refreshToken 통신
  - accessToken이 유효하지 않을 시 클라이언트에게 refreshToken을 보내달라고 요청
  - 이후 refreshToken이 유효하다면 newAccessToken을 만들어 보내주고 아니면 에러 반환

## 관련된 이슈 넘버
#250 #249 