### PR TITLE
리액트 컴포넌트 최적화

### DIFF
--- a/frontend/src/components/Sidebar/FirstDepth/index.tsx
+++ b/frontend/src/components/Sidebar/FirstDepth/index.tsx
@@ -29,7 +29,7 @@ const FirstDepth = ({ isToggle, setIsToggle, addGroupBtnRef }: FirstDepthProps) 
 
   useEffect(() => {
     dispatch(GroupAction.setSelectedGroupIdxAction({ selectedGroupIdx: 0 }));
-    dispatch(GroupAction.getAlbumListAction(groups[0]));
+    groups.length !== 0 && dispatch(GroupAction.getAlbumListAction(groups[0]));
   }, []);
 
   useEffect(() => {

--- a/frontend/src/components/Sidebar/SecondDepth/AddAlbum/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AddAlbum/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React from "react";
 import styled from "styled-components";
 import { flexRowCenterAlign } from "@src/styles/StyledComponents";
 import COLOR from "@styles/Color";
@@ -9,7 +9,7 @@ import { ModalAction } from "@src/action";
 
 const AddAlbum = () => {
   const { nowTheme }: any = useSelector((state: RootState) => state.theme);
-  const { isAddAlbumModalOpened }: any = useSelector((state: RootState) => state.modal);
+  const isAddAlbumModalOpened = useSelector((state: RootState) => state.modal.isAddAlbumModalOpened);
   const dispatch = useDispatch();
 
   const onClickAddAlbum = () => {
@@ -48,4 +48,4 @@ const GuideWrapper = styled.div`
   margin-left: 10px;
 `;
 
-export default AddAlbum;
+export default React.memo(AddAlbum);

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Album/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Album/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import Header from "@components/Sidebar/SecondDepth/AlbumList/Header";
 import Post from "@components/Sidebar/SecondDepth/AlbumList/Post";
+import styled from "styled-components";
 
 interface AlbumProps {
   albumIdx: number;
@@ -29,7 +30,14 @@ const Album = ({
 }: AlbumProps) => {
   const [postToggle, setPostToggle] = useState(true);
   return (
-    <div onDrop={DropHandler} onDragLeave={DragLeaveHandler} onDragOver={(e) => e.preventDefault()}>
+    <AlbumWrapper
+      className="albumItem"
+      onDrop={DropHandler}
+      onDragLeave={DragLeaveHandler}
+      onDragOver={(e) => e.preventDefault()}
+      data-albumidx={albumIdx}
+      data-album-id={album.albumId}
+    >
       <Header
         albumId={album.albumId}
         albumName={album.albumName}
@@ -52,8 +60,14 @@ const Album = ({
             album={album}
           />
         ))}
-    </div>
+    </AlbumWrapper>
   );
 };
 
+const AlbumWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 99%;
+  margin: 1rem 0;
+`;
 export default React.memo(Album);

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Album/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Album/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import Header from "@components/Sidebar/SecondDepth/AlbumList/Header";
 import Post from "@components/Sidebar/SecondDepth/AlbumList/Post";
 
@@ -56,4 +56,4 @@ const Album = ({
   );
 };
 
-export default Album;
+export default React.memo(Album);

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Header/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Header/index.tsx
@@ -20,7 +20,7 @@ interface HeaderProps {
 
 const Header = ({ albumId, albumName, postToggle, setPostToggle, AlbumDragHandler, DragEndHandler }: HeaderProps) => {
   const { nowTheme }: any = useSelector((state: RootState) => state.theme);
-  const { albumSettingWrapperModalIdx } = useSelector((state: RootState) => state.modal);
+  const albumSettingWrapperModalIdx = useSelector((state: RootState) => state.modal.albumSettingWrapperModalIdx);
   const dispatch = useDispatch();
   const [pos, setPos] = useState([-1, -1]);
 

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/Post/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/Post/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction } from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import styled from "styled-components";
 import COLOR from "@styles/Color";
 import { useDispatch } from "react-redux";
@@ -72,4 +72,4 @@ const PostTitle = styled.div`
   white-space: nowrap;
 `;
 
-export default Post;
+export default React.memo(Post);

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/index.tsx
@@ -132,21 +132,19 @@ const AlbumList = () => {
       {albumList &&
         albumList.map((album: any, idx: number) => {
           return (
-            <AlbumWrapper key={album.albumId} className="albumItem" data-albumidx={idx} data-album-id={album.albumId}>
-              <Album
-                key={album.albumId}
-                album={album}
-                postSelected={postSelected}
-                setPostSelected={setPostSelected}
-                AlbumDragEndHandler={onAlbumDragEndHandler}
-                DropHandler={onDropHandler}
-                PostDragHandler={onPostDragHandler}
-                AlbumDragHandler={onAlbumDragHandler}
-                DragLeaveHandler={onDragLeaveHandler}
-                PostDragEndHandler={onPostDragEndHandler}
-                albumIdx={idx}
-              ></Album>
-            </AlbumWrapper>
+            <Album
+              key={album.albumId}
+              album={album}
+              postSelected={postSelected}
+              setPostSelected={setPostSelected}
+              AlbumDragEndHandler={onAlbumDragEndHandler}
+              DropHandler={onDropHandler}
+              PostDragHandler={onPostDragHandler}
+              AlbumDragHandler={onAlbumDragHandler}
+              DragLeaveHandler={onDragLeaveHandler}
+              PostDragEndHandler={onPostDragEndHandler}
+              albumIdx={idx}
+            ></Album>
           );
         })}
     </DraggableWrapper>
@@ -173,12 +171,6 @@ const DraggableWrapper = styled.div`
       border-radius: 1rem;
     }
   }
-`;
-const AlbumWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 99%;
-  margin: 1rem 0;
 `;
 
 export default React.memo(AlbumList);

--- a/frontend/src/components/Sidebar/SecondDepth/AlbumList/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/AlbumList/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import styled from "styled-components";
 import { useSelector } from "react-redux";
 import { RootState } from "@src/reducer";
@@ -12,27 +12,27 @@ const AlbumList = () => {
   const [postSelected, setPostSelected] = useState<number>(-1);
   const { albumList, selectedGroup }: any = useSelector((state: RootState) => state.groups);
   const clickedTarget = useSelector((state: RootState) => state.groupModal.clickedTarget);
-  const { selectedPost }: any = useSelector((state: RootState) => state.modal);
   const draggableRef = useRef<HTMLDivElement>(null);
 
-  function onDragLeaveHandler(ev: React.DragEvent<HTMLDivElement>) {
+  const onDragLeaveHandler = useCallback((ev: React.DragEvent<HTMLDivElement>) => {
     ev.preventDefault();
     const target = ev.target as HTMLElement;
     const parent = target.closest(".albumItem");
     if (!parent) return;
     parent?.classList.remove("album-hover");
     parent?.classList.remove("post-hover");
-  }
-  function onDropHandler(ev: React.DragEvent<HTMLDivElement>) {
-    ev.preventDefault();
-    const target = ev.target as HTMLElement;
-    const parent = target.closest(".albumItem");
-    if (!parent) return;
-    parent?.classList.remove("album-hover");
-    parent?.classList.remove("post-hover");
-  }
+  }, []);
 
-  function onAlbumDragEndHandler(ev: React.DragEvent<HTMLDivElement>) {
+  const onDropHandler = useCallback((ev: React.DragEvent<HTMLDivElement>) => {
+    ev.preventDefault();
+    const target = ev.target as HTMLElement;
+    const parent = target.closest(".albumItem");
+    if (!parent) return;
+    parent?.classList.remove("album-hover");
+    parent?.classList.remove("post-hover");
+  }, []);
+
+  const onAlbumDragEndHandler = useCallback((ev: React.DragEvent<HTMLDivElement>) => {
     ev.preventDefault();
     const target = ev.target as HTMLElement;
     const parent = target.closest(".albumItem");
@@ -62,9 +62,9 @@ const AlbumList = () => {
       })
       .join(",");
     dispatch(GroupAction.updateAlbumOrderAction(selectedGroup.groupId, albumOrder));
-  }
+  }, []);
 
-  function onPostDragEndHandler(ev: React.DragEvent<HTMLDivElement>) {
+  const onPostDragEndHandler = useCallback((ev: React.DragEvent<HTMLDivElement>) => {
     ev.preventDefault();
     const target = ev.target as HTMLElement;
     const parent = target.closest(".albumItem");
@@ -80,9 +80,9 @@ const AlbumList = () => {
     const postInfo = { postId, postTitle, albumId: postAlbumId };
     const albumId: number = Number(nowParent.dataset.albumId);
     dispatch(GroupAction.postShiftAlbumAction(postInfo, albumId));
-  }
+  }, []);
 
-  function onPostDragHandler(ev: React.DragEvent<HTMLDivElement>) {
+  const onPostDragHandler = useCallback((ev: React.DragEvent<HTMLDivElement>) => {
     ev.preventDefault();
     const target = ev.target as HTMLElement;
     const parent = target.closest(".albumItem");
@@ -93,9 +93,9 @@ const AlbumList = () => {
     if (!nowParent) return;
     if (parent === nowParent) return;
     nowParent.classList.add("post-hover");
-  }
+  }, []);
 
-  function onAlbumDragHandler(ev: React.DragEvent<HTMLDivElement>) {
+  const onAlbumDragHandler = useCallback((ev: React.DragEvent<HTMLDivElement>) => {
     ev.preventDefault();
     const target = ev.target as HTMLElement;
     const parent = target.closest(".albumItem");
@@ -106,7 +106,7 @@ const AlbumList = () => {
     if (!nowParent) return;
     if (parent === nowParent) return;
     nowParent.classList.add("album-hover");
-  }
+  }, []);
 
   useEffect(() => {
     const clickHandler = () => {
@@ -123,13 +123,9 @@ const AlbumList = () => {
     clickHandler();
   }, [clickedTarget]);
 
-  useEffect(() => {
-    setPostSelected(selectedPost.postId);
-  }, [selectedPost]);
-
-  const scrollHandler = () => {
+  const scrollHandler = useCallback(() => {
     dispatch(ModalAction.setAlbumSettingWrapperModalIdxAction({ albumSettingWrapperModalIdx: -1 }));
-  };
+  }, []);
 
   return (
     <DraggableWrapper ref={draggableRef} onScroll={scrollHandler}>
@@ -138,6 +134,7 @@ const AlbumList = () => {
           return (
             <AlbumWrapper key={album.albumId} className="albumItem" data-albumidx={idx} data-album-id={album.albumId}>
               <Album
+                key={album.albumId}
                 album={album}
                 postSelected={postSelected}
                 setPostSelected={setPostSelected}
@@ -184,4 +181,4 @@ const AlbumWrapper = styled.div`
   margin: 1rem 0;
 `;
 
-export default AlbumList;
+export default React.memo(AlbumList);

--- a/frontend/src/components/Sidebar/SecondDepth/SettingGroup/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/SettingGroup/index.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import styled from "styled-components";
 import COLOR from "@styles/Color";
 import { useDispatch } from "react-redux";
@@ -70,4 +71,4 @@ const SettingIconWrapper = styled.div`
   ${flexRowCenterAlign};
 `;
 
-export default SettingGroup;
+export default React.memo(SettingGroup);

--- a/frontend/src/components/Sidebar/SecondDepth/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/index.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useEffect } from "react";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@src/reducer";
 import styled, { keyframes } from "styled-components";
@@ -70,4 +70,4 @@ const SecondDepthWrapper = styled.div<{ isToggle: boolean }>`
   animation-duration: 1s;
 `;
 
-export default SecondDepth;
+export default React.memo(SecondDepth);

--- a/frontend/src/components/Sidebar/SecondDepth/index.tsx
+++ b/frontend/src/components/Sidebar/SecondDepth/index.tsx
@@ -15,8 +15,8 @@ interface SecondDepthProps {
 
 const SecondDepth = ({ isToggle }: SecondDepthProps) => {
   const { selectedGroup } = useSelector((state: RootState) => state.groups);
-  const { isAddAlbumModalOpened } = useSelector((state: RootState) => state.modal);
-  const { clickedTarget } = useSelector((state: RootState) => state.groupModal);
+  const isAddAlbumModalOpened = useSelector((state: RootState) => state.modal.isAddAlbumModalOpened);
+  const clickedTarget = useSelector((state: RootState) => state.groupModal.clickedTarget);
   const dispatch = useDispatch();
 
   useEffect(() => {

--- a/frontend/src/components/Sidebar/index.tsx
+++ b/frontend/src/components/Sidebar/index.tsx
@@ -19,9 +19,8 @@ const Sidebar = ({ isToggle, setIsToggle }: SidebarProps) => {
 };
 
 const SidebarWrapper = styled.nav`
-  display: inline-flex;
+  display: flex;
   font-size: 1.6rem;
-  width: 29rem;
 `;
 
 export default React.memo(Sidebar);

--- a/frontend/src/components/Sidebar/index.tsx
+++ b/frontend/src/components/Sidebar/index.tsx
@@ -1,6 +1,4 @@
-import { useEffect, useRef, useState, Dispatch, SetStateAction } from "react";
-import { useSelector } from "react-redux";
-import { RootState } from "@src/reducer";
+import React, { useRef, Dispatch, SetStateAction } from "react";
 import styled from "styled-components";
 import FirstDepth from "./FirstDepth";
 import SecondDepth from "./SecondDepth";
@@ -26,4 +24,4 @@ const SidebarWrapper = styled.nav`
   width: 29rem;
 `;
 
-export default Sidebar;
+export default React.memo(Sidebar);

--- a/frontend/src/pages/Main/index.tsx
+++ b/frontend/src/pages/Main/index.tsx
@@ -63,8 +63,16 @@ const Main = () => {
     <>
       {spinnerActivate ? <Spinner /> : null}
       <Header />
-      <Sidebar isToggle={isToggle} setIsToggle={setIsToggle} />
-      <Content>{groups.length > 0 ? <Map /> : <Empty />}</Content>
+      <Content>
+        {groups.length > 0 ? (
+          <>
+            <Sidebar isToggle={isToggle} setIsToggle={setIsToggle} />
+            <Map />
+          </>
+        ) : (
+          <Empty />
+        )}
+      </Content>
       <ModalManager setIsToggle={setIsToggle} />
       <ToastManager />
     </>
@@ -73,9 +81,5 @@ const Main = () => {
 
 const Content = styled.main`
   display: flex;
-  position: absolute;
-  width: calc(100% - 9rem);
-  top: 5vh;
-  left: 9rem;
 `;
 export default Main;


### PR DESCRIPTION
## 작업 내용
### 지도 클릭시 사이드바 리렌더링이 최대한 안되도록 막아봤습니다.

![video1](https://user-images.githubusercontent.com/50266862/144042259-5a602717-9ba7-4cd1-84db-7854f10097f7.gif)

## 고민한 부분
- styled component 렌더링을 막기 위해 key값을 포함한 다른 속성들을 리액트 컴포넌트로 옮겼습니다.
- clickedTarget 처리를 어떻게 해야할지?
- useCallback, React.memo를 써서 불필요한 렌더링을 줄여봤습니다.

## 리뷰 포인트
필상이가 `clickedTarget` 관한 이슈를 헤결해서 아마 위 움짤도 해결될 듯 싶습니다.

## 관련된 이슈 넘버
#255 